### PR TITLE
Add S3 support to CLI and fix clippy warnings

### DIFF
--- a/band-songbook/CHANGELOG.md
+++ b/band-songbook/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.5] - 2026-02-04
+
+### Changed
+- CLI now supports S3 paths for srcdir, sandbox, and settings arguments
+- Main function is now async using tokio runtime
+- Uses `make_all_with_storage` for unified local/S3 path handling
+
 ## [0.0.4] - 2026-02-04
 
 ### Added

--- a/band-songbook/src/chords/parse.rs
+++ b/band-songbook/src/chords/parse.rs
@@ -130,10 +130,8 @@ pub fn parse(input: &str) -> Result<ParsedRow, ParseError> {
     let bars: Result<Vec<Bar>, ParseError> = bar_parts
         .iter()
         .map(|bar_str| {
-            let items: Result<Vec<BarItem>, ParseError> = bar_str
-                .split_whitespace()
-                .map(parse_item)
-                .collect();
+            let items: Result<Vec<BarItem>, ParseError> =
+                bar_str.split_whitespace().map(parse_item).collect();
             Ok(Bar { items: items? })
         })
         .collect();

--- a/band-songbook/src/helpers/handlebar_helpers.rs
+++ b/band-songbook/src/helpers/handlebar_helpers.rs
@@ -145,11 +145,7 @@ pub fn bar_rects_helper(
     let parsed = parse(input).map_err(|e| RenderErrorReason::Other(e.to_string()))?;
 
     for (i, bar) in parsed.bars.iter().enumerate() {
-        let glyphs: Vec<_> = bar
-            .items
-            .iter()
-            .map(glyph_of_baritem)
-            .collect();
+        let glyphs: Vec<_> = bar.items.iter().map(glyph_of_baritem).collect();
 
         if glyphs.len() >= 2 {
             // Two or more chords: draw rectangle, then position first chord up 10%, second down 10%

--- a/band-songbook/src/main.rs
+++ b/band-songbook/src/main.rs
@@ -1,65 +1,98 @@
 use argh::FromArgs;
-use band_songbook::make_all;
-use std::path::PathBuf;
+use band_songbook::{StoragePath, make_all_with_storage};
 use std::process::ExitCode;
 
 #[derive(FromArgs)]
 /// Build all songs in a directory
 struct Args {
-    /// source directory containing song.yml files
+    /// source directory containing song.yml files (local path or s3://bucket/prefix)
     #[argh(option, short = 's')]
-    srcdir: PathBuf,
+    srcdir: String,
 
-    /// output directory for built files
+    /// output directory for built files (local path or s3://bucket/prefix)
     #[argh(option, short = 'o')]
-    sandbox: PathBuf,
+    sandbox: String,
 
-    /// path to settings.yml file
+    /// path to settings.yml file (local path or s3://bucket/key)
     #[argh(option, short = 'c')]
-    settings: Option<PathBuf>,
+    settings: Option<String>,
 
     /// pattern to filter songs (e.g. "black_keys" or "red_hot*")
     #[argh(option, short = 'p')]
     pattern: Option<String>,
 }
 
-fn main() -> ExitCode {
+#[tokio::main]
+async fn main() -> ExitCode {
     env_logger::init();
     let args: Args = argh::from_env();
 
-    if !args.srcdir.exists() {
-        eprintln!("Error: srcdir '{}' does not exist", args.srcdir.display());
-        return ExitCode::from(1);
+    // Validate srcdir exists for local paths
+    let srcdir_path = match StoragePath::parse(&args.srcdir) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: invalid srcdir: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    if let Some(local_path) = srcdir_path.as_local() {
+        if !local_path.exists() {
+            eprintln!("Error: srcdir '{}' does not exist", local_path.display());
+            return ExitCode::from(1);
+        }
     }
 
-    if let Err(e) = std::fs::create_dir_all(&args.sandbox) {
-        eprintln!(
-            "Error: failed to create sandbox '{}': {}",
-            args.sandbox.display(),
-            e
-        );
-        return ExitCode::from(1);
+    // Validate sandbox path for local paths - create if needed
+    let sandbox_path = match StoragePath::parse(&args.sandbox) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: invalid sandbox: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    if let Some(local_path) = sandbox_path.as_local() {
+        if let Err(e) = std::fs::create_dir_all(local_path) {
+            eprintln!(
+                "Error: failed to create sandbox '{}': {}",
+                local_path.display(),
+                e
+            );
+            return ExitCode::from(1);
+        }
     }
 
-    let (success, g) = make_all(
+    let result: Result<(bool, band_songbook::G), String> = make_all_with_storage(
         &args.srcdir,
         &args.sandbox,
         args.settings.as_deref(),
         args.pattern.as_deref(),
-    );
+    )
+    .await;
 
-    // Write mermaid graph to sandbox
-    let graph_path = args.sandbox.join("graph.md");
-    let graph_content = format!("# graph\n\n```mermaid\n\n{}\n```\n", g.to_mermaid());
-    if let Err(e) = std::fs::write(&graph_path, graph_content) {
-        eprintln!("Warning: failed to write graph.md: {e}");
-    }
+    match result {
+        Ok((success, g)) => {
+            // Write mermaid graph to sandbox (only for local paths)
+            if let Some(local_sandbox) = sandbox_path.as_local() {
+                let graph_path = local_sandbox.join("graph.md");
+                let graph_content = format!("# graph\n\n```mermaid\n\n{}\n```\n", g.to_mermaid());
+                if let Err(e) = std::fs::write(&graph_path, graph_content) {
+                    eprintln!("Warning: failed to write graph.md: {e}");
+                }
+            }
 
-    if success {
-        println!("Build succeeded");
-        ExitCode::SUCCESS
-    } else {
-        eprintln!("Build failed");
-        ExitCode::from(1)
+            if success {
+                println!("Build succeeded");
+                ExitCode::SUCCESS
+            } else {
+                eprintln!("Build failed");
+                ExitCode::from(1)
+            }
+        }
+        Err(e) => {
+            eprintln!("Error: {e}");
+            ExitCode::from(1)
+        }
     }
 }

--- a/band-songbook/src/main_lambda.rs
+++ b/band-songbook/src/main_lambda.rs
@@ -1,5 +1,5 @@
 use band_songbook::make_all_with_storage;
-use lambda_runtime::{run, service_fn, Error, LambdaEvent};
+use lambda_runtime::{Error, LambdaEvent, run, service_fn};
 use serde::{Deserialize, Serialize};
 
 /// S3 Event notification structure
@@ -51,11 +51,12 @@ struct Config {
 
 impl Config {
     fn from_env() -> Result<Self, String> {
-        let srcdir = std::env::var("SRCDIR")
-            .unwrap_or_else(|_| "s3://zik-laurent/songs".to_string());
-        let sandbox = std::env::var("SANDBOX")
-            .unwrap_or_else(|_| "s3://zik-laurent/sandbox".to_string());
-        let settings = std::env::var("SETTINGS").ok()
+        let srcdir =
+            std::env::var("SRCDIR").unwrap_or_else(|_| "s3://zik-laurent/songs".to_string());
+        let sandbox =
+            std::env::var("SANDBOX").unwrap_or_else(|_| "s3://zik-laurent/sandbox".to_string());
+        let settings = std::env::var("SETTINGS")
+            .ok()
             .or_else(|| Some("s3://zik-laurent/songs/settings.yml".to_string()));
 
         Ok(Config {
@@ -91,12 +92,12 @@ async fn function_handler(event: LambdaEvent<S3Event>) -> Result<Response, Error
     };
 
     // Get configuration from environment
-    let config = Config::from_env().map_err(|e| Error::from(e))?;
+    let config = Config::from_env().map_err(Error::from)?;
 
     log::info!("srcdir: {}", &config.srcdir);
     log::info!("sandbox: {}", &config.sandbox);
     if let Some(ref settings) = config.settings {
-        log::info!("settings: {}", settings);
+        log::info!("settings: {settings}");
     }
 
     match make_all_with_storage(
@@ -113,7 +114,7 @@ async fn function_handler(event: LambdaEvent<S3Event>) -> Result<Response, Error
             } else {
                 "Build completed with errors".to_string()
             };
-            log::info!("{}", message);
+            log::info!("{message}");
             Ok(Response {
                 request_id,
                 success,
@@ -122,11 +123,11 @@ async fn function_handler(event: LambdaEvent<S3Event>) -> Result<Response, Error
             })
         }
         Err(e) => {
-            log::error!("Build failed: {}", e);
+            log::error!("Build failed: {e}");
             Ok(Response {
                 request_id,
                 success: false,
-                message: format!("Build failed: {}", e),
+                message: format!("Build failed: {e}"),
                 triggered_by,
             })
         }

--- a/band-songbook/src/nodes/pdf.rs
+++ b/band-songbook/src/nodes/pdf.rs
@@ -96,7 +96,7 @@ impl GNode for PdfFile {
                 Err(e) => {
                     log::error!("Failed to run lualatex: {} for {}", e, self.path.display());
                     let stderr_path = sandbox.join("logs").join(format!("{}.stderr", &node_id));
-                    let _ = std::fs::write(&stderr_path, format!("Failed to run lualatex: {}", e));
+                    let _ = std::fs::write(&stderr_path, format!("Failed to run lualatex: {e}"));
                     return false;
                 }
             };

--- a/band-songbook/src/nodes/pdfcopyfile.rs
+++ b/band-songbook/src/nodes/pdfcopyfile.rs
@@ -25,10 +25,7 @@ impl GNode for PdfCopyFile {
         let pdf_predecessor = match predecessors.iter().find(|p| p.tag() == "pdf") {
             Some(pred) => *pred,
             None => {
-                log::error!(
-                    "PdfCopyFile {} has no pdf predecessor",
-                    self.path.display()
-                );
+                log::error!("PdfCopyFile {} has no pdf predecessor", self.path.display());
                 return false;
             }
         };

--- a/band-songbook/src/nodes/songyml.rs
+++ b/band-songbook/src/nodes/songyml.rs
@@ -161,7 +161,8 @@ impl GRootNode for SongYml {
 \begin{document}
 \input{body}
 \end{document}
-"#.to_string();
+"#
+        .to_string();
         if let Err(e) = std::fs::write(&tex_full_path, &tex_content) {
             log::error!("Failed to write main.tex: {e}");
             return Err(ExpandError::Other(e.to_string()));

--- a/band-songbook/src/tests.rs
+++ b/band-songbook/src/tests.rs
@@ -98,8 +98,7 @@ mod tests {
             "final",
         ];
         for name in lyrics_files {
-            let lyrics_path =
-                PathBuf::from(format!("mademoiselle_K/ca_me_vexe/lyrics/{name}.tex"));
+            let lyrics_path = PathBuf::from(format!("mademoiselle_K/ca_me_vexe/lyrics/{name}.tex"));
             let lyrics_node = TexFile::new(lyrics_path);
             let _ = g.add_root_node(lyrics_node);
         }
@@ -446,11 +445,11 @@ mod tests {
 
         match &result {
             Ok((success, _g)) => {
-                println!("Build completed, success: {}", success);
+                println!("Build completed, success: {success}");
                 assert!(*success, "Build should succeed");
             }
             Err(e) => {
-                panic!("make_all_with_storage failed: {}", e);
+                panic!("make_all_with_storage failed: {e}");
             }
         }
     }


### PR DESCRIPTION
## Summary
- CLI now supports S3 paths (s3://bucket/prefix) for srcdir, sandbox, and settings arguments
- Main function is now async using tokio runtime with `make_all_with_storage`
- Fixed all clippy warnings across the codebase (format string inlining, strip_prefix usage, redundant closures)

## Test plan
- [ ] Test CLI with local paths (existing behavior)
- [ ] Test CLI with S3 paths for srcdir
- [ ] Test CLI with S3 paths for sandbox output
- [ ] Verify clippy passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)