### PR TITLE
Fix Lambda logging by adding tracing-log feature

### DIFF
--- a/band-songbook/CHANGELOG.md
+++ b/band-songbook/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.6] - 2026-02-04
+
+### Fixed
+- Lambda now shows application logs in CloudWatch (added `tracing-log` feature)
+
 ## [0.0.5] - 2026-02-04
 
 ### Changed

--- a/band-songbook/Cargo.toml
+++ b/band-songbook/Cargo.toml
@@ -31,7 +31,7 @@ tempfile = "3"
 # Lambda dependencies
 lambda_runtime = "0.13"
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "tracing-log"] }
 
 [[bin]]
 name = "band-songbook"


### PR DESCRIPTION
## Summary
- Added `tracing-log` feature to `tracing-subscriber` dependency
- This bridges `log::info!()`, `log::error!()` macros to the tracing subscriber
- Application logs will now appear in CloudWatch

## Root cause
The Lambda used `tracing_subscriber::fmt()` but application code uses `log::*` macros. Without `tracing-log`, these are not captured.

## Test plan
- [ ] Deploy Lambda and invoke
- [ ] Verify application logs appear in CloudWatch (srcdir, sandbox, build errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)