### PR TITLE
Improve error logging and refactor local_sandbox handling

### DIFF
--- a/band-songbook/CHANGELOG.md
+++ b/band-songbook/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.7] - 2026-02-05
+
+### Changed
+- `make_all_with_storage` now takes `local_sandbox` as explicit parameter
+- Lambda uses fixed `/tmp/sandbox` path instead of temp directory
+
+### Improved
+- lilypond-book errors now log stdout and stderr content for easier debugging
+
 ## [0.0.6] - 2026-02-04
 
 ### Fixed

--- a/band-songbook/src/main_lambda.rs
+++ b/band-songbook/src/main_lambda.rs
@@ -100,9 +100,13 @@ async fn function_handler(event: LambdaEvent<S3Event>) -> Result<Response, Error
         log::info!("settings: {settings}");
     }
 
+    // Use a fixed path for local sandbox (Lambda only has /tmp writable)
+    let local_sandbox = std::path::Path::new("/tmp/sandbox");
+
     match make_all_with_storage(
         &config.srcdir,
         &config.sandbox,
+        local_sandbox,
         config.settings.as_deref(),
         None, // no pattern filter
     )

--- a/band-songbook/src/tests.rs
+++ b/band-songbook/src/tests.rs
@@ -413,7 +413,8 @@ mod tests {
         let sandbox_path = sandbox.path().to_str().unwrap();
         let settings = "tests/data/settings.yml";
 
-        let result = make_all_with_storage(srcdir, sandbox_path, Some(settings), None).await;
+        let result =
+            make_all_with_storage(srcdir, sandbox_path, sandbox.path(), Some(settings), None).await;
 
         assert!(result.is_ok(), "make_all_with_storage should succeed");
         let (success, _g) = result.unwrap();
@@ -440,8 +441,11 @@ mod tests {
         let srcdir = "s3://zik-laurent/songs";
         let sandbox = "s3://zik-laurent/output";
         let settings = "s3://zik-laurent/songs/settings.yml";
+        let local_sandbox = tempfile::tempdir().expect("Failed to create temp dir");
 
-        let result = make_all_with_storage(srcdir, sandbox, Some(settings), None).await;
+        let result =
+            make_all_with_storage(srcdir, sandbox, local_sandbox.path(), Some(settings), None)
+                .await;
 
         match &result {
             Ok((success, _g)) => {


### PR DESCRIPTION
## Summary
- lilypond-book errors now log stdout and stderr content for debugging
- `make_all_with_storage` takes `local_sandbox` as explicit parameter instead of creating temp dir
- Lambda uses fixed `/tmp/sandbox` path
- CLI creates temp dir when sandbox is S3, uses local path otherwise

## Test plan
- [ ] Deploy Lambda and invoke
- [ ] Verify lilypond-book errors show stdout/stderr in CloudWatch logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)