### PR TITLE
Update LilyPond to 2.24.4

### DIFF
--- a/band-songbook/Dockerfile
+++ b/band-songbook/Dockerfile
@@ -34,12 +34,12 @@ RUN dnf update -y && dnf install -y \
 
 # Install LilyPond manually (not available in AL2023 repos)
 RUN cd /tmp && \
-    wget -q https://gitlab.com/lilypond/lilypond/-/releases/v2.24.3/downloads/lilypond-2.24.3-linux-x86_64.tar.gz && \
-    tar -xzf lilypond-2.24.3-linux-x86_64.tar.gz && \
-    mv lilypond-2.24.3 /opt/lilypond && \
+    wget -q https://gitlab.com/lilypond/lilypond/-/releases/v2.24.4/downloads/lilypond-2.24.4-linux-x86_64.tar.gz && \
+    tar -xzf lilypond-2.24.4-linux-x86_64.tar.gz && \
+    mv lilypond-2.24.4 /opt/lilypond && \
     ln -s /opt/lilypond/bin/lilypond /usr/local/bin/lilypond && \
     ln -s /opt/lilypond/bin/lilypond-book /usr/local/bin/lilypond-book && \
-    rm -f lilypond-2.24.3-linux-x86_64.tar.gz
+    rm -f lilypond-2.24.4-linux-x86_64.tar.gz
 
 # Copy the Lambda binary
 COPY --from=builder /usr/src/app/target/x86_64-unknown-linux-musl/release/band-songbook-lambda ${LAMBDA_RUNTIME_DIR}/bootstrap


### PR DESCRIPTION
## Summary
- Update LilyPond from 2.24.3 to 2.24.4 in Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)