### PR TITLE
Log stdout/stderr when lualatex fails

### DIFF
--- a/band-songbook/src/nodes/pdf.rs
+++ b/band-songbook/src/nodes/pdf.rs
@@ -90,6 +90,8 @@ impl GNode for PdfFile {
                             out.status.code(),
                             self.path.display()
                         );
+                        log::error!("stdout : {stdout}");
+                        log::error!("stderr : {stderr}");
                     }
                     stdout
                 }


### PR DESCRIPTION
Adds error logging for lualatex stdout/stderr on build failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)