### PR TITLE
Add bar count display and tracking in TikZ diagrams

### DIFF
--- a/band-songbook/src/helpers/handlebar_helpers.rs
+++ b/band-songbook/src/helpers/handlebar_helpers.rs
@@ -224,12 +224,12 @@ pub fn ref_bar_count_helper(
             "missing link parameter".to_string(),
         ))?;
 
-    let structure = h
-        .param(1)
-        .and_then(|v| v.value().as_array())
-        .ok_or(RenderErrorReason::Other(
-            "missing structure parameter".to_string(),
-        ))?;
+    let structure =
+        h.param(1)
+            .and_then(|v| v.value().as_array())
+            .ok_or(RenderErrorReason::Other(
+                "missing structure parameter".to_string(),
+            ))?;
 
     // Find the referenced section by id
     let mut total_bars: u32 = 0;

--- a/band-songbook/src/helpers/handlebar_helpers.rs
+++ b/band-songbook/src/helpers/handlebar_helpers.rs
@@ -207,6 +207,57 @@ pub fn row_multiplier_helper(
     Ok(())
 }
 
+/// Returns the total bar count for a referenced section (by link/id)
+/// Calculates sum of (number_of_bars * repeat) for each row in the referenced Chords section
+/// Usage: {{ref_bar_count link song.structure}}
+pub fn ref_bar_count_helper(
+    h: &Helper,
+    _: &Handlebars,
+    _: &Context,
+    _: &mut RenderContext,
+    out: &mut dyn Output,
+) -> Result<(), RenderError> {
+    let link = h
+        .param(0)
+        .and_then(|v| v.value().as_str())
+        .ok_or(RenderErrorReason::Other(
+            "missing link parameter".to_string(),
+        ))?;
+
+    let structure = h
+        .param(1)
+        .and_then(|v| v.value().as_array())
+        .ok_or(RenderErrorReason::Other(
+            "missing structure parameter".to_string(),
+        ))?;
+
+    // Find the referenced section by id
+    let mut total_bars: u32 = 0;
+    for item in structure {
+        let id = item.get("id").and_then(|v| v.as_str());
+        if id == Some(link) {
+            // Found the referenced section, check if it's a Chords section
+            if let Some(chords) = item.get("item").and_then(|v| v.get("Chords")) {
+                if let Some(rows) = chords.get("rows").and_then(|v| v.as_array()) {
+                    for row in rows {
+                        if let Some(row_str) = row.as_str() {
+                            if let Ok(parsed) = parse(row_str) {
+                                let bars = parsed.bars.len() as u32;
+                                let repeat = parsed.repeat.n;
+                                total_bars += bars * repeat;
+                            }
+                        }
+                    }
+                }
+            }
+            break;
+        }
+    }
+
+    out.write(&total_bars.to_string())?;
+    Ok(())
+}
+
 /// Registers all custom helpers with the handlebars instance
 pub fn register_helpers(handlebars: &mut Handlebars) {
     handlebars.register_helper("len-helper", Box::new(len_helper));
@@ -215,6 +266,7 @@ pub fn register_helpers(handlebars: &mut Handlebars) {
     handlebars.register_helper("bar_glyph", Box::new(bar_glyph_helper));
     handlebars.register_helper("bar_rects", Box::new(bar_rects_helper));
     handlebars.register_helper("row_multiplier", Box::new(row_multiplier_helper));
+    handlebars.register_helper("ref_bar_count", Box::new(ref_bar_count_helper));
 }
 
 #[cfg(test)]

--- a/band-songbook/src/resources/texfiles/song.tikz
+++ b/band-songbook/src/resources/texfiles/song.tikz
@@ -34,6 +34,7 @@
     \tikzmath{\currentline=\topline;}
     \tikzmath{\columnleft=0;}
     \tikzmath{\columnwidth=\xxxcolumnwidth;}
+    \tikzmath{\barcount=1;}
 
     % Song title
     \coordinate (A) at (\xr*2+\xxxcolumnwidth/2,.5) ;
@@ -72,22 +73,26 @@
 {{#each this.item.Chords.rows}}
     \coordinate (A1) at (\columnleft + \xr * {{number_of_bars this}}, \currentline);
     \coordinate (A2) at ($(A1) + (0, -\yr)$);
+    \node[anchor=east] at (\columnleft - 0.02, \currentline - 0.85*\yr) { \fontsize{8pt}{8pt}\selectfont \pgfmathprintnumber[precision=0]{\barcount} };
 {{{bar_rects this ../this.item.Chords.color}}}
 {{#if (gt (row_multiplier this) 1)}}
     \node[anchor=west] at (\columnleft + \xr * {{number_of_bars this}} + 0.1, \currentline - 0.5*\yr) { \fontsize{10pt}{10pt}\selectfont\bfseries x{{row_multiplier this}} };
 {{/if}}
     \tikzmath{\currentline = \currentline - \yr;}
+    \tikzmath{\barcount = \barcount + {{number_of_bars this}} * {{row_multiplier this}};}
 {{/each}}
     \coordinate (B) at (\columnleft, \currentline);
     \coordinate (C) at ($(A)!0.5!(B)$);
-    \coordinate (D) at ($(C) + (-\titlexoffset, 0)$);
+    \coordinate (D) at ($(C) + (-\titlexoffset - 0.5, 0)$);
     \node[ellipse, fill={{this.item.Chords.color}}, inner sep=3pt, rotate=70] at (D) { \fontsize{12pt}{12pt}\selectfont\bfseries {{{this.item.Chords.title}}} };
     \tikzmath{\currentline = \currentline - \spacebetweensections;}
 {{/if}}
 {{#if this.item.Ref}}
+    \node[anchor=east] at (\columnleft + \xr - 0.02, \currentline - 0.35*\yr) { \fontsize{8pt}{8pt}\selectfont \pgfmathprintnumber[precision=0]{\barcount} };
     \draw[draw=black, fill={{this.item.Ref.color}}] (\columnleft + \xr, \currentline) rectangle ++(2*\xr, -\yr/2) node[midway] { {{{this.item.Ref.title}}} };
     \tikzmath{\currentline = \currentline - \yr/2;}
     \tikzmath{\currentline = \currentline - \spacebetweensections;}
+    \tikzmath{\barcount = \barcount + {{ref_bar_count this.item.Ref.link @root.song.structure}};}
 {{/if}}
 {{#if (eq this.item "NewColumn")}}
     \tikzmath{\columnleft = \columnleft + \columnwidth;}


### PR DESCRIPTION
## Summary
- Add barcount variable to track bar numbers throughout song structure
- Display bar number at the left of each row (Chords and Ref sections)
- Add `ref_bar_count` helper to calculate total bars for referenced sections (including repeats)
- Add `row_multiplier` display (xN) at end of rows when multiplier > 1
- Move section label slightly more to the left for better layout

## Test plan
- [x] Run `cargo fmt` and `cargo clippy`
- [x] Build test songs with `cargo run --bin band-songbook -- --srcdir tests/data --sandbox sandbox --settings tests/data/settings.yml`
- [ ] Verify bar numbers appear correctly in generated PDFs

🤖 Generated with [Claude Code](https://claude.com/claude-code)