### PR TITLE
Replace Times New Roman with TeX Gyre Termes

### DIFF
--- a/band-songbook/Dockerfile
+++ b/band-songbook/Dockerfile
@@ -57,9 +57,6 @@ ENV PATH="/opt/lilypond/bin:${PATH}"
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 ENV RUST_LOG=info
-ENV SRCDIR=s3://zik-laurent/songs
-ENV SANDBOX=s3://zik-laurent/sandbox
-ENV SETTINGS=s3://zik-laurent/songs/settings.yml
 
 # Lambda handler
 CMD [ "bootstrap" ]

--- a/band-songbook/src/resources/texfiles/main-lyrics.tex
+++ b/band-songbook/src/resources/texfiles/main-lyrics.tex
@@ -21,7 +21,7 @@
 \end{center}
 \vspace{1em}
 
-\setmainfont{Times New Roman}
+\setmainfont{TeX Gyre Termes}
 \setlength{\columnseprule}{0.4pt}
 \begin{multicols}{2}
 {{{lyrics_inputs}}}

--- a/band-songbook/tests/data/settings.yml
+++ b/band-songbook/tests/data/settings.yml
@@ -1,5 +1,5 @@
 # Settings for song rendering
-lyrics_font: "\\setmainfont{Times New Roman}"
+lyrics_font: "\\setmainfont{TeX Gyre Termes}"
 
 # Default colors for section types (x11 color names)
 colors:


### PR DESCRIPTION
## Summary
- Replace `Times New Roman` with `TeX Gyre Termes` in lyrics PDF template and test settings
- TeX Gyre Termes is a metric-compatible replacement bundled with TeX Live
- Remove stale `SRCDIR`, `SANDBOX`, `SETTINGS` env vars from Dockerfile

## Test plan
- [x] All 24 tests pass
- [ ] Deploy Lambda and verify lyrics PDFs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)