### PR TITLE
Auto-publish to crates.io on push to main

### DIFF
--- a/.github/workflows/publish-band-songbook.yml
+++ b/.github/workflows/publish-band-songbook.yml
@@ -2,8 +2,10 @@ name: Publish band-songbook
 
 on:
   push:
-    tags:
-      - 'band-songbook-v*'
+    branches:
+      - main
+    paths:
+      - 'band-songbook/**'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -60,7 +62,26 @@ jobs:
             band-songbook/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Get crate version
+        id: crate_version
+        working-directory: band-songbook
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 | python3 -c "import sys,json; print(json.load(sys.stdin)['packages'][0]['version'])")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if version is already published
+        id: check_published
+        run: |
+          if cargo search band-songbook --limit 1 | grep -q "^band-songbook = \"${{ steps.crate_version.outputs.version }}\""; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${{ steps.crate_version.outputs.version }} is already published on crates.io"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+            echo "Version ${{ steps.crate_version.outputs.version }} is not yet published"
+          fi
+
       - name: Verify package
+        if: steps.check_published.outputs.already_published == 'false'
         working-directory: band-songbook
         run: cargo package --list
 
@@ -70,7 +91,9 @@ jobs:
         run: cargo publish --dry-run
 
       - name: Publish to crates.io
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')
+        if: |
+          steps.check_published.outputs.already_published == 'false' &&
+          (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false'))
         working-directory: band-songbook
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/band-songbook/CHANGELOG.md
+++ b/band-songbook/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Replace Times New Roman with TeX Gyre Termes in lyrics PDF template (Lambda compatible)
+- Publish workflow now triggers automatically on push to `main` (replaces tag-based trigger)
+- Publish skips if the version is already on crates.io
+- Bump `Cargo.toml` version to match changelog; fix repository URL
 
 ### Removed
 - Stale `SRCDIR`, `SANDBOX`, `SETTINGS` env vars from Dockerfile

--- a/band-songbook/Cargo.toml
+++ b/band-songbook/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "band-songbook"
-version = "0.0.4"
+version = "0.0.10"
 edition = "2024"
 description = "Build system for generating PDF songbooks with chord charts and LilyPond music notation"
 license = "MIT"
-repository = "https://github.com/laurentcarrie/legendary-memory"
+repository = "https://github.com/laurentcarrie/songbook-lambda"
 readme = "../README.md"
 keywords = ["music", "songbook", "chords", "lilypond", "latex"]
 categories = ["command-line-utilities", "multimedia"]


### PR DESCRIPTION
## Summary
- Replace tag-based publish trigger with push-to-main trigger (path-filtered to `band-songbook/**`)
- Add version check step to skip publish when the version is already on crates.io
- Bump crate version `0.0.4` → `0.0.10` to match changelog and fix repository URL
- Replace Times New Roman with TeX Gyre Termes for Lambda font compatibility
- Add mandatory `--delivery` CLI argument and simplify sandbox to local-only
- Improve Lambda and S3 upload functionality
- Clean up obsolete deploy scripts and workflows

## Test plan
- [ ] `cargo test --lib` passes (18 tests)
- [ ] `cargo clippy` clean
- [ ] Merge to main triggers publish workflow
- [ ] Workflow skips publish if version already exists on crates.io
- [ ] Manual `workflow_dispatch` dry run still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)