### PR TITLE
Add two lyrics PDF variants (1-column and 2-column)

### DIFF
--- a/band-songbook/CHANGELOG.md
+++ b/band-songbook/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.11] - 2026-02-08
+
+### Added
+- Two lyrics PDF variants per song: 1-column and 2-column layouts
+  - Delivered to `pdf-lyrics-1-column/` and `pdf-lyrics-2-column/` directories
+- Bar number ranges displayed in lyrics section headers (e.g., "couplet 1 (9 -> 16)")
+- `settings.lyrics_font` now uses `\setmainfont` (fontspec) instead of `\fontfamily` (NFSS) for proper lualatex compatibility
+
+### Changed
+- `\basecouplet` title box now spans full column width
+- `\basecouplet` content starts on a new line below the title
+- Lyrics PDFs use `\basecouplet` macro (same as main PDF) for consistent font rendering
+- 1-column lyrics layout is centered; 2-column is left-aligned
+
+### Removed
+- Single `pdf-lyrics/` delivery directory (replaced by two variant directories)
+
 ## [0.0.10] - 2026-02-08
 
 ### Changed

--- a/band-songbook/Cargo.toml
+++ b/band-songbook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "band-songbook"
-version = "0.0.10"
+version = "0.0.11"
 edition = "2024"
 description = "Build system for generating PDF songbooks with chord charts and LilyPond music notation"
 license = "MIT"

--- a/band-songbook/src/lib.rs
+++ b/band-songbook/src/lib.rs
@@ -94,10 +94,12 @@ pub fn make_all(
         log::error!("Failed to create pdf directory: {e}");
     }
 
-    // Create pdf-lyrics directory for copied lyrics PDFs
-    let pdf_lyrics_dir = sandbox.join("pdf-lyrics");
-    if let Err(e) = std::fs::create_dir_all(&pdf_lyrics_dir) {
-        log::error!("Failed to create pdf-lyrics directory: {e}");
+    // Create pdf-lyrics directories for copied lyrics PDFs (1-column and 2-column)
+    for dir in ["pdf-lyrics-1-column", "pdf-lyrics-2-column"] {
+        let pdf_lyrics_dir = sandbox.join(dir);
+        if let Err(e) = std::fs::create_dir_all(&pdf_lyrics_dir) {
+            log::error!("Failed to create {dir} directory: {e}");
+        }
     }
 
     for song_path in songs {
@@ -171,18 +173,22 @@ pub fn make_all(
                 g.add_edge(pdf_idx, pdf_copy_idx);
             }
 
-            // Create lyrics PdfFile node
-            let lyrics_pdf_path = parent_dir.join("lyrics").join("main.pdf");
-            let lyrics_pdf_node = PdfFile::new(lyrics_pdf_path.clone());
-            if let Ok(lyrics_pdf_idx) = g.add_node(lyrics_pdf_node) {
-                g.add_edge(song_idx, lyrics_pdf_idx);
+            // Create lyrics PdfFile nodes (1-column and 2-column)
+            for (filename, delivery_dir) in [
+                ("main-1col.pdf", "pdf-lyrics-1-column"),
+                ("main-2col.pdf", "pdf-lyrics-2-column"),
+            ] {
+                let lyrics_pdf_path = parent_dir.join("lyrics").join(filename);
+                let lyrics_pdf_node = PdfFile::new(lyrics_pdf_path.clone());
+                if let Ok(lyrics_pdf_idx) = g.add_node(lyrics_pdf_node) {
+                    g.add_edge(song_idx, lyrics_pdf_idx);
 
-                // Create PdfCopyFile node for lyrics PDF
-                let lyrics_copy_path = Path::new("../pdf-lyrics")
-                    .join(format!("{}-lyrics.pdf", song_data.info.pdf_name_of_song()));
-                let lyrics_copy_node = PdfCopyFile::new(lyrics_copy_path);
-                if let Ok(lyrics_copy_idx) = g.add_node(lyrics_copy_node) {
-                    g.add_edge(lyrics_pdf_idx, lyrics_copy_idx);
+                    let lyrics_copy_path = Path::new(&format!("../{delivery_dir}"))
+                        .join(format!("{}-lyrics.pdf", song_data.info.pdf_name_of_song()));
+                    let lyrics_copy_node = PdfCopyFile::new(lyrics_copy_path);
+                    if let Ok(lyrics_copy_idx) = g.add_node(lyrics_copy_node) {
+                        g.add_edge(lyrics_pdf_idx, lyrics_copy_idx);
+                    }
                 }
             }
         }
@@ -298,12 +304,7 @@ pub async fn make_all_with_storage(
     }
 
     // Run the build
-    let (success, g) = make_all(
-        &local_srcdir,
-        sandbox,
-        local_settings.as_deref(),
-        pattern,
-    );
+    let (success, g) = make_all(&local_srcdir, sandbox, local_settings.as_deref(), pattern);
 
     // Helper function to collect files recursively
     fn collect_files_recursive(dir: &std::path::Path, files: &mut Vec<std::path::PathBuf>) {
@@ -328,19 +329,24 @@ pub async fn make_all_with_storage(
             collect_files_recursive(&pdf_dir, &mut delivery_files);
         }
 
-        let pdf_lyrics_dir = sandbox.join("pdf-lyrics");
-        if pdf_lyrics_dir.exists() {
-            collect_files_recursive(&pdf_lyrics_dir, &mut delivery_files);
+        for dir in ["pdf-lyrics-1-column", "pdf-lyrics-2-column"] {
+            let pdf_lyrics_dir = sandbox.join(dir);
+            if pdf_lyrics_dir.exists() {
+                collect_files_recursive(&pdf_lyrics_dir, &mut delivery_files);
+            }
         }
 
-        log::info!("Uploading {} delivery files to {delivery}", delivery_files.len());
+        log::info!(
+            "Uploading {} delivery files to {delivery}",
+            delivery_files.len()
+        );
         storage::upload_paths_to_s3(&delivery_files, sandbox, &delivery_path).await?;
     } else {
         let local_delivery = delivery_path.as_local().unwrap();
         std::fs::create_dir_all(local_delivery)
             .map_err(|e| format!("Failed to create delivery directory: {e}"))?;
 
-        for subdir in &["pdf", "pdf-lyrics"] {
+        for subdir in &["pdf", "pdf-lyrics-1-column", "pdf-lyrics-2-column"] {
             let src_dir = sandbox.join(subdir);
             if !src_dir.exists() {
                 continue;

--- a/band-songbook/src/nodes/songyml.rs
+++ b/band-songbook/src/nodes/songyml.rs
@@ -16,7 +16,8 @@ const SECTIONS_TEMPLATE: &str = include_str!("../resources/texfiles/sections.tex
 const CHORDS_TEX: &str = include_str!("../resources/texfiles/chords.tex");
 const DATA_TEMPLATE: &str = include_str!("../resources/texfiles/data.tex");
 const MACROS_LY_TEMPLATE: &str = include_str!("../resources/lyfiles/macros.ly");
-const MAIN_LYRICS_TEMPLATE: &str = include_str!("../resources/texfiles/main-lyrics.tex");
+const MAIN_LYRICS_1COL_TEMPLATE: &str = include_str!("../resources/texfiles/main-lyrics-1col.tex");
+const MAIN_LYRICS_2COL_TEMPLATE: &str = include_str!("../resources/texfiles/main-lyrics-2col.tex");
 
 pub struct SongYml {
     pub path: PathBuf,
@@ -275,14 +276,11 @@ impl GRootNode for SongYml {
             return Err(ExpandError::Other(e.to_string()));
         }
 
-        // Create lyrics/main.tex file with inputs for each Chords/Ref section
-        let lyrics_tex_path = parent_dir.join("lyrics").join("main.tex");
-        let lyrics_tex_full_path = sandbox.join(&lyrics_tex_path);
-        if let Some(parent) = lyrics_tex_full_path.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
+        // Create lyrics tex files with inputs for each Chords/Ref section
+        let lyrics_dir_full = sandbox.join(parent_dir.join("lyrics"));
+        let _ = std::fs::create_dir_all(&lyrics_dir_full);
 
-        // Build the lyrics/main.tex content
+        // Build the lyrics_inputs content (shared by both 1col and 2col)
         let bar_map = barcount_map_of_structure(&song.structure);
         let mut lyrics_inputs = String::new();
         for item in &song.structure {
@@ -294,7 +292,7 @@ impl GRootNode for SongYml {
                         .map(|(rows, end)| (rows.first().copied().unwrap_or(1), end - 1))
                         .unwrap_or((1, 1));
                     lyrics_inputs.push_str(&format!(
-                        "\\noindent\\colorbox{{{}}}{{\\makebox[\\dimexpr\\columnwidth-2\\fboxsep][s]{{\\hfill \\Large\\textbf{{{}}} \\hfill {} $\\rightarrow$ {}}}}}\n\n\\input{{{}}}\n\\vspace{{1em}}\n\n",
+                        "\\basecouplet{{{}}}{{ {} ({} $\\rightarrow$ {}) }}{{\\input{{{}}}}}\n\n",
                         color, chords.title, first_bar, last_bar, item.id
                     ));
                 }
@@ -305,7 +303,7 @@ impl GRootNode for SongYml {
                         .map(|(rows, end)| (rows.first().copied().unwrap_or(1), end - 1))
                         .unwrap_or((1, 1));
                     lyrics_inputs.push_str(&format!(
-                        "\\noindent\\colorbox{{{}}}{{\\makebox[\\dimexpr\\columnwidth-2\\fboxsep][s]{{\\hfill \\Large\\textbf{{{}}} \\hfill {} $\\rightarrow$ {}}}}}\n\n\\input{{{}}}\n\\vspace{{1em}}\n\n",
+                        "\\basecouplet{{{}}}{{ {} ({} $\\rightarrow$ {}) }}{{\\input{{{}}}}}\n\n",
                         color, ref_section.title, first_bar, last_bar, item.id
                     ));
                 }
@@ -313,20 +311,26 @@ impl GRootNode for SongYml {
             }
         }
 
-        let lyrics_template_data =
-            serde_json::json!({"song": song_data, "lyrics_inputs": lyrics_inputs});
-        let lyrics_tex_content =
-            match handlebars.render_template(MAIN_LYRICS_TEMPLATE, &lyrics_template_data) {
+        let lyrics_template_data = serde_json::json!({"song": song_data, "lyrics_inputs": lyrics_inputs, "settings": settings});
+
+        // Render and write both 1-column and 2-column lyrics tex files
+        for (template, filename) in [
+            (MAIN_LYRICS_1COL_TEMPLATE, "main-1col.tex"),
+            (MAIN_LYRICS_2COL_TEMPLATE, "main-2col.tex"),
+        ] {
+            let tex_content = match handlebars.render_template(template, &lyrics_template_data) {
                 Ok(content) => content,
                 Err(e) => {
-                    log::error!("Failed to render main-lyrics.tex template: {e}");
+                    log::error!("Failed to render {filename} template: {e}");
                     return Err(ExpandError::Other(e.to_string()));
                 }
             };
 
-        if let Err(e) = std::fs::write(&lyrics_tex_full_path, &lyrics_tex_content) {
-            log::error!("Failed to write lyrics/main.tex: {e}");
-            return Err(ExpandError::Other(e.to_string()));
+            let tex_full_path = lyrics_dir_full.join(filename);
+            if let Err(e) = std::fs::write(&tex_full_path, &tex_content) {
+                log::error!("Failed to write lyrics/{filename}: {e}");
+                return Err(ExpandError::Other(e.to_string()));
+            }
         }
 
         // Create nodes (body.tex and lyrics files are added as root nodes in make_all)
@@ -338,7 +342,12 @@ impl GRootNode for SongYml {
         let chords_node = TexFile::new(chords_path);
         let data_node = TexFile::new(data_path);
         let macros_ly_node = LilypondFile::new(macros_ly_path);
-        let lyrics_tex_node = TexFile::new(lyrics_tex_path.clone());
+
+        // Lyrics nodes: 1-column and 2-column variants
+        let lyrics_1col_tex_path = parent_dir.join("lyrics").join("main-1col.tex");
+        let lyrics_2col_tex_path = parent_dir.join("lyrics").join("main-2col.tex");
+        let lyrics_1col_tex_node = TexFile::new(lyrics_1col_tex_path.clone());
+        let lyrics_2col_tex_node = TexFile::new(lyrics_2col_tex_path.clone());
 
         // Scan for lilypond files referenced in tex files
         let pdf_for_scan = PdfFile::new(pdf_path.clone());
@@ -350,9 +359,11 @@ impl GRootNode for SongYml {
         // Included .ly files (from \include) don't need LyTexFile/TexOfLilypond
         let ly_files = toplevel_ly;
 
-        // Create lyrics PDF path
-        let lyrics_pdf_path = parent_dir.join("lyrics").join("main.pdf");
-        let lyrics_pdf_node = PdfFile::new(lyrics_pdf_path.clone());
+        // Create lyrics PDF paths (1-column and 2-column)
+        let lyrics_1col_pdf_path = parent_dir.join("lyrics").join("main-1col.pdf");
+        let lyrics_2col_pdf_path = parent_dir.join("lyrics").join("main-2col.pdf");
+        let lyrics_1col_pdf_node = PdfFile::new(lyrics_1col_pdf_path.clone());
+        let lyrics_2col_pdf_node = PdfFile::new(lyrics_2col_pdf_path.clone());
 
         let mut nodes: Vec<Box<dyn GNode + Send + Sync>> = vec![
             Box::new(tex_node),
@@ -363,8 +374,10 @@ impl GRootNode for SongYml {
             Box::new(chords_node),
             Box::new(data_node),
             Box::new(macros_ly_node),
-            Box::new(lyrics_tex_node),
-            Box::new(lyrics_pdf_node),
+            Box::new(lyrics_1col_tex_node),
+            Box::new(lyrics_2col_tex_node),
+            Box::new(lyrics_1col_pdf_node),
+            Box::new(lyrics_2col_pdf_node),
         ];
 
         let mut edges: Vec<Edge> = vec![];
@@ -378,12 +391,19 @@ impl GRootNode for SongYml {
         };
         edges.push(main_edge);
 
-        // Edge: lyrics/main.tex -> lyrics/main.pdf
-        let lyrics_edge = Edge {
-            nfrom: Box::new(TexFile::new(lyrics_tex_path)),
-            nto: Box::new(PdfFile::new(lyrics_pdf_path)),
+        // Edge: lyrics/main-1col.tex -> lyrics/main-1col.pdf
+        let lyrics_1col_edge = Edge {
+            nfrom: Box::new(TexFile::new(lyrics_1col_tex_path)),
+            nto: Box::new(PdfFile::new(lyrics_1col_pdf_path)),
         };
-        edges.push(lyrics_edge);
+        edges.push(lyrics_1col_edge);
+
+        // Edge: lyrics/main-2col.tex -> lyrics/main-2col.pdf
+        let lyrics_2col_edge = Edge {
+            nfrom: Box::new(TexFile::new(lyrics_2col_tex_path)),
+            nto: Box::new(PdfFile::new(lyrics_2col_pdf_path)),
+        };
+        edges.push(lyrics_2col_edge);
 
         // Add LilypondFile -> LyTexFile -> PdfFile chain
         // Add LilypondFile -> TexOfLilypond -> PdfFile chain

--- a/band-songbook/src/resources/texfiles/data.tex
+++ b/band-songbook/src/resources/texfiles/data.tex
@@ -17,7 +17,7 @@
 \renewcommand{\songlyrics}{
 
 {{#if settings.lyrics_font}}
-{\fontfamily{ {{~settings.lyrics_font~}} }\selectfont
+{\setmainfont{ {{~settings.lyrics_font~}} }
 {{/if}}
 {\setstretch{1.2}
 

--- a/band-songbook/src/resources/texfiles/main-lyrics-1col.tex
+++ b/band-songbook/src/resources/texfiles/main-lyrics-1col.tex
@@ -1,0 +1,30 @@
+\documentclass{article}
+\PassOptionsToPackage{x11names}{xcolor}
+\input{../preamble}
+
+\begin{document}
+\begin{center}
+{
+    \Fontskrivan\bfseries\slshape
+    \fontsize{40pt}{35pt}\selectfont
+    \color{blue}
+    {{{song.info.title}}}
+} \\[0.5em]
+{
+    \textcursive{
+        \bfseries
+        \fontsize{16pt}{12pt}\selectfont
+        \color{orange}
+        {{{song.info.author}}}
+    }
+}
+\end{center}
+\vspace{1em}
+
+{{#if settings.lyrics_font}}
+\setmainfont{ {{~settings.lyrics_font~}} }
+{{/if}}
+\setstretch{1.2}
+\centering
+{{{lyrics_inputs}}}
+\end{document}

--- a/band-songbook/src/resources/texfiles/main-lyrics-2col.tex
+++ b/band-songbook/src/resources/texfiles/main-lyrics-2col.tex
@@ -21,7 +21,10 @@
 \end{center}
 \vspace{1em}
 
-\setmainfont{TeX Gyre Termes}
+{{#if settings.lyrics_font}}
+\setmainfont{ {{~settings.lyrics_font~}} }
+{{/if}}
+\setstretch{1.2}
 \setlength{\columnseprule}{0.4pt}
 \begin{multicols}{2}
 {{{lyrics_inputs}}}

--- a/band-songbook/src/resources/texfiles/preamble.tex
+++ b/band-songbook/src/resources/texfiles/preamble.tex
@@ -89,10 +89,10 @@
 
 
 \newcommand{\basecouplet}[3]{
-	\fcolorbox{gray}{#1}{
+	\fcolorbox{gray}{#1}{\makebox[\dimexpr\columnwidth-2\fboxsep-2\fboxrule][c]{
 		\fontsize{18pt}{18pt}\selectfont
 		#2
-	}
+	}}\newline
 	{
 		{
 				\fontsize{16pt}{16pt}\selectfont

--- a/band-songbook/src/tests.rs
+++ b/band-songbook/src/tests.rs
@@ -127,9 +127,9 @@ fn test_yamake_build_song_with_lilypond() {
 
     // Verify interlude.ly is in the predecessor tree of main.pdf
     let predecessors = g.root_predecessors(pdf_idx);
-    let interlude_is_predecessor = predecessors.iter().any(|&idx| {
-        g.g[idx].pathbuf() == PathBuf::from("mademoiselle_K/ca_me_vexe/interlude.ly")
-    });
+    let interlude_is_predecessor = predecessors
+        .iter()
+        .any(|&idx| g.g[idx].pathbuf() == PathBuf::from("mademoiselle_K/ca_me_vexe/interlude.ly"));
     assert!(
         interlude_is_predecessor,
         "interlude.ly should be a predecessor of main.pdf"

--- a/band-songbook/tests/data/settings.yml
+++ b/band-songbook/tests/data/settings.yml
@@ -1,5 +1,5 @@
 # Settings for song rendering
-lyrics_font: "\\setmainfont{TeX Gyre Termes}"
+lyrics_font: TeX Gyre Termes
 
 # Default colors for section types (x11 color names)
 colors:


### PR DESCRIPTION
## Summary
- Generate two lyrics PDFs per song: 1-column (`pdf-lyrics-1-column/`) and 2-column (`pdf-lyrics-2-column/`) replacing the single `pdf-lyrics/` directory
- Both lyrics variants use the `\basecouplet` macro for consistent font rendering with the main PDF
- Title box in `\basecouplet` now spans full column width with lyrics starting on a new line
- Switch `settings.lyrics_font` from NFSS `\fontfamily` to fontspec `\setmainfont` for proper lualatex compatibility

## Test plan
- [x] `cargo test --lib` — 24 passed, 1 ignored (S3)
- [x] `cargo fmt` — clean
- [x] `cargo clippy` — clean
- [x] Build a song, verify both `delivery/pdf-lyrics-1-column/` and `delivery/pdf-lyrics-2-column/` contain PDFs with correct layouts
- [x] Verify font rendering matches between main PDF and lyrics PDFs

🤖 Generated with [Claude Code](https://claude.com/claude-code)