### PR TITLE
Right-align bar numbering in lyrics PDF section titles

### DIFF
--- a/band-songbook/src/nodes/songyml.rs
+++ b/band-songbook/src/nodes/songyml.rs
@@ -292,7 +292,7 @@ impl GRootNode for SongYml {
                         .map(|(rows, end)| (rows.first().copied().unwrap_or(1), end - 1))
                         .unwrap_or((1, 1));
                     lyrics_inputs.push_str(&format!(
-                        "\\basecouplet{{{}}}{{ {} ({} $\\rightarrow$ {}) }}{{\\input{{{}}}}}\n\n",
+                        "\\basecouplet{{{}}}{{ \\hfill {} \\hfill \\llap{{\\fontsize{{12pt}}{{12pt}}\\selectfont ({} $\\rightarrow$ {})}} }}{{\\input{{{}}}}}\n\n",
                         color, chords.title, first_bar, last_bar, item.id
                     ));
                 }
@@ -303,7 +303,7 @@ impl GRootNode for SongYml {
                         .map(|(rows, end)| (rows.first().copied().unwrap_or(1), end - 1))
                         .unwrap_or((1, 1));
                     lyrics_inputs.push_str(&format!(
-                        "\\basecouplet{{{}}}{{ {} ({} $\\rightarrow$ {}) }}{{\\input{{{}}}}}\n\n",
+                        "\\basecouplet{{{}}}{{ \\hfill {} \\hfill \\llap{{\\fontsize{{12pt}}{{12pt}}\\selectfont ({} $\\rightarrow$ {})}} }}{{\\input{{{}}}}}\n\n",
                         color, ref_section.title, first_bar, last_bar, item.id
                     ));
                 }

--- a/band-songbook/src/resources/texfiles/preamble.tex
+++ b/band-songbook/src/resources/texfiles/preamble.tex
@@ -89,10 +89,11 @@
 
 
 \newcommand{\basecouplet}[3]{
-	\fcolorbox{gray}{#1}{\makebox[\dimexpr\columnwidth-2\fboxsep-2\fboxrule][c]{
+	\vspace{6pt}
+	\fcolorbox{gray}{#1}{\parbox{\dimexpr\columnwidth-2\fboxsep-2\fboxrule}{
 		\fontsize{18pt}{18pt}\selectfont
 		#2
-	}}\newline
+	}}\\[6pt]
 	{
 		{
 				\fontsize{16pt}{16pt}\selectfont


### PR DESCRIPTION
## Summary
- Center section titles with bar ranges right-aligned and smaller (12pt vs 18pt) in lyrics PDFs
- Use `\parbox` + `\hfill` + `\llap` layout for centered title with right-aligned bar numbering
- Add 6pt vertical spacing before and after section title boxes

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy` — clean
- [x] `cargo test --lib` — 24 passed
- [x] Full rebuild — 290 builds succeeded
- [x] Visual check of lyrics PDFs confirms layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)