### PR TITLE
Add Strudel HTML generation from drum patterns

### DIFF
--- a/band-songbook/Cargo.toml
+++ b/band-songbook/Cargo.toml
@@ -17,8 +17,7 @@ log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
-yamake = "0.1.9"
-#yamake = { path = "../../yamake" }
+yamake = "0.1.10"
 object_store = { version = "0.13", features = ["aws"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 # Pin AWS SDK crates to versions compatible with Rust 1.85
@@ -27,6 +26,7 @@ aws-credential-types = "1.2"
 url = "2"
 futures = "0.3"
 tempfile = "3"
+strudel-of-lilypond = "0.4.1"
 
 # Lambda dependencies
 lambda_runtime = "0.13"

--- a/band-songbook/examples/build_song.rs
+++ b/band-songbook/examples/build_song.rs
@@ -12,7 +12,7 @@ fn main() {
     std::fs::create_dir_all(sandbox).expect("Failed to create sandbox directory");
 
     println!("Building all songs...");
-    let (success, _g) = make_all(srcdir, sandbox, None, None);
+    let (success, _g) = make_all(srcdir, sandbox, None, None, &[]);
 
     if success {
         println!("Build succeeded!");

--- a/band-songbook/src/chords/bar_numbering.rs
+++ b/band-songbook/src/chords/bar_numbering.rs
@@ -70,6 +70,7 @@ mod tests {
                     section_body: None,
                     color: None,
                     rows: vec!["Am|G".to_string(), "F|E".to_string()], // 2 bars each row
+                    drum_sequence: None,
                 }),
             },
             StructureItem {
@@ -80,6 +81,7 @@ mod tests {
                     section_body: None,
                     color: None,
                     rows: vec!["C|G|Am|F".to_string(), "C|G|x2".to_string()], // 4 bars, then 2 bars x2
+                    drum_sequence: None,
                 }),
             },
             StructureItem {

--- a/band-songbook/src/helpers/mod.rs
+++ b/band-songbook/src/helpers/mod.rs
@@ -1,3 +1,5 @@
 pub mod handlebar_helpers;
+pub mod sequence;
 
 pub use handlebar_helpers::register_helpers;
+pub use sequence::strudel_sequence_of_song;

--- a/band-songbook/src/helpers/sequence.rs
+++ b/band-songbook/src/helpers/sequence.rs
@@ -1,0 +1,323 @@
+use std::collections::HashMap;
+
+use strudel_of_lilypond::sequencer::model::{Bar, BarSequence, EBarSequence, SequenceItem};
+
+use crate::chords::parse::parse;
+use crate::model::{SectionItem, StructureItem};
+
+/// Builds a [`BarSequence`] from a song's structure, resolving `Ref`
+/// sections and mapping repeats to `EBarSequence` variants.
+///
+/// `HRule` and `NewColumn` items are skipped since they carry no musical
+/// content.
+pub fn strudel_sequence_of_song(structure: &[StructureItem], tempo: u16) -> BarSequence {
+    // Pre-index Chords sections so Ref lookups are O(1).
+    let chords_map: HashMap<&str, &crate::model::ChordsSection> = structure
+        .iter()
+        .filter_map(|item| match &item.item {
+            SectionItem::Chords(chords) => Some((item.id.as_str(), chords)),
+            _ => None,
+        })
+        .collect();
+
+    let mut sequence = Vec::new();
+
+    for item in structure {
+        match &item.item {
+            SectionItem::Chords(chords) => {
+                let items =
+                    rows_to_ebarsequence(&chords.rows, chords.drum_sequence.as_deref(), &item.id);
+                if !items.is_empty() {
+                    sequence.push(SequenceItem {
+                        description: chords.title.clone(),
+                        item: if items.len() == 1 {
+                            items.into_iter().next().unwrap()
+                        } else {
+                            EBarSequence::Group(items)
+                        },
+                    });
+                }
+            }
+            SectionItem::Ref(ref_section) => {
+                if let Some(chords) = chords_map.get(ref_section.link.as_str()) {
+                    let items = rows_to_ebarsequence(
+                        &chords.rows,
+                        chords.drum_sequence.as_deref(),
+                        &item.id,
+                    );
+                    if !items.is_empty() {
+                        sequence.push(SequenceItem {
+                            description: ref_section.title.clone(),
+                            item: if items.len() == 1 {
+                                items.into_iter().next().unwrap()
+                            } else {
+                                EBarSequence::Group(items)
+                            },
+                        });
+                    }
+                } else {
+                    log::warn!(
+                        "Ref section '{}' links to unknown id '{}'",
+                        item.id,
+                        ref_section.link
+                    );
+                }
+            }
+            SectionItem::HRule(_) | SectionItem::NewColumn => {}
+        }
+    }
+
+    BarSequence {
+        tempo: tempo as u32,
+        sequence,
+    }
+}
+
+/// Expands a `DrumSequence` into a flat list of pattern names, repeating
+/// each item according to its `repeat` count.
+fn expand_drum_sequence(drum_sequence: &[crate::model::DrumSequenceItem]) -> Vec<&str> {
+    drum_sequence
+        .iter()
+        .flat_map(|item| std::iter::repeat_n(item.pattern.as_str(), item.repeat as usize))
+        .collect()
+}
+
+/// Converts chord rows into a list of `EBarSequence` items.
+///
+/// Each row is parsed into bars. If the row has a repeat (xN), the bars are
+/// wrapped in a `RepeatGroup` or `RepeatBar`. Pattern names are taken from
+/// `drum_sequence` (expanded in order); bars beyond the drum sequence length
+/// fall back to `"default-bar"`.
+fn rows_to_ebarsequence(
+    rows: &[String],
+    drum_sequence: Option<&[crate::model::DrumSequenceItem]>,
+    section_id: &str,
+) -> Vec<EBarSequence> {
+    let patterns = drum_sequence.map(expand_drum_sequence).unwrap_or_default();
+    let mut pattern_idx = 0;
+    let mut items = Vec::new();
+
+    for row in rows {
+        match parse(row) {
+            Ok(parsed) => {
+                let bars: Vec<EBarSequence> = parsed
+                    .bars
+                    .iter()
+                    .map(|_| {
+                        let name = patterns.get(pattern_idx).copied().unwrap_or("default-bar");
+                        pattern_idx += 1;
+                        EBarSequence::Single(Bar {
+                            pattern_name: name.to_string(),
+                        })
+                    })
+                    .collect();
+
+                if bars.is_empty() {
+                    continue;
+                }
+
+                let row_item = if parsed.repeat.n > 1 {
+                    if bars.len() == 1 {
+                        if let EBarSequence::Single(bar) = bars.into_iter().next().unwrap() {
+                            EBarSequence::RepeatBar(parsed.repeat.n, bar)
+                        } else {
+                            unreachable!()
+                        }
+                    } else {
+                        EBarSequence::RepeatGroup(parsed.repeat.n, bars)
+                    }
+                } else if bars.len() == 1 {
+                    bars.into_iter().next().unwrap()
+                } else {
+                    EBarSequence::Group(bars)
+                };
+
+                items.push(row_item);
+            }
+            Err(e) => {
+                log::warn!("Failed to parse row '{row}' in section '{section_id}': {e}");
+            }
+        }
+    }
+
+    items
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ChordsSection, DrumSequenceItem, RefSection};
+
+    #[test]
+    fn test_strudel_sequence_basic() {
+        let structure = vec![
+            StructureItem {
+                id: "intro".to_string(),
+                item: SectionItem::Chords(ChordsSection {
+                    title: "Intro".to_string(),
+                    section_type: "intro".to_string(),
+                    section_body: None,
+                    color: None,
+                    rows: vec!["Am|G".to_string()],
+                    drum_sequence: None,
+                }),
+            },
+            StructureItem {
+                id: "couplet1".to_string(),
+                item: SectionItem::Chords(ChordsSection {
+                    title: "Couplet 1".to_string(),
+                    section_type: "couplet".to_string(),
+                    section_body: None,
+                    color: None,
+                    rows: vec!["C|G|Am|F".to_string()],
+                    drum_sequence: None,
+                }),
+            },
+        ];
+
+        let seq = strudel_sequence_of_song(&structure, 120);
+        assert_eq!(seq.tempo, 120);
+        assert_eq!(seq.sequence.len(), 2);
+        assert_eq!(seq.sequence[0].description, "Intro");
+        assert_eq!(seq.sequence[1].description, "Couplet 1");
+    }
+
+    #[test]
+    fn test_strudel_sequence_with_repeat() {
+        let structure = vec![StructureItem {
+            id: "verse".to_string(),
+            item: SectionItem::Chords(ChordsSection {
+                title: "Verse".to_string(),
+                section_type: "couplet".to_string(),
+                section_body: None,
+                color: None,
+                rows: vec!["Em|G|x2".to_string()],
+                drum_sequence: None,
+            }),
+        }];
+
+        let seq = strudel_sequence_of_song(&structure, 140);
+        assert_eq!(seq.sequence.len(), 1);
+        // Should be a RepeatGroup(2, [...])
+        match &seq.sequence[0].item {
+            EBarSequence::RepeatGroup(n, bars) => {
+                assert_eq!(*n, 2);
+                assert_eq!(bars.len(), 2);
+            }
+            other => panic!("Expected RepeatGroup, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_strudel_sequence_with_ref() {
+        let structure = vec![
+            StructureItem {
+                id: "intro".to_string(),
+                item: SectionItem::Chords(ChordsSection {
+                    title: "Intro".to_string(),
+                    section_type: "intro".to_string(),
+                    section_body: None,
+                    color: None,
+                    rows: vec!["Am|G".to_string()],
+                    drum_sequence: None,
+                }),
+            },
+            StructureItem {
+                id: "refrain2".to_string(),
+                item: SectionItem::Ref(RefSection {
+                    title: "Refrain 2".to_string(),
+                    section_type: None,
+                    section_body: None,
+                    color: None,
+                    link: "intro".to_string(),
+                }),
+            },
+        ];
+
+        let seq = strudel_sequence_of_song(&structure, 120);
+        assert_eq!(seq.sequence.len(), 2);
+        assert_eq!(seq.sequence[0].description, "Intro");
+        assert_eq!(seq.sequence[1].description, "Refrain 2");
+    }
+
+    #[test]
+    fn test_strudel_sequence_skips_hrule_and_newcolumn() {
+        let structure = vec![
+            StructureItem {
+                id: "intro".to_string(),
+                item: SectionItem::Chords(ChordsSection {
+                    title: "Intro".to_string(),
+                    section_type: "intro".to_string(),
+                    section_body: None,
+                    color: None,
+                    rows: vec!["Am|G".to_string()],
+                    drum_sequence: None,
+                }),
+            },
+            StructureItem {
+                id: "hr".to_string(),
+                item: SectionItem::HRule(100),
+            },
+            StructureItem {
+                id: "nc".to_string(),
+                item: SectionItem::NewColumn,
+            },
+        ];
+
+        let seq = strudel_sequence_of_song(&structure, 120);
+        assert_eq!(seq.sequence.len(), 1);
+    }
+
+    #[test]
+    fn test_strudel_sequence_with_drum_sequence() {
+        // 4 bars: Am|G (2 bars) + C|D (2 bars)
+        // drum_sequence: 1x "rock-intro", 2x "rock-verse", 1x "fill-1"
+        let structure = vec![StructureItem {
+            id: "verse".to_string(),
+            item: SectionItem::Chords(ChordsSection {
+                title: "Verse".to_string(),
+                section_type: "couplet".to_string(),
+                section_body: None,
+                color: None,
+                rows: vec!["Am|G".to_string(), "C|D".to_string()],
+                drum_sequence: Some(vec![
+                    DrumSequenceItem {
+                        repeat: 1,
+                        pattern: "rock-intro".to_string(),
+                    },
+                    DrumSequenceItem {
+                        repeat: 2,
+                        pattern: "rock-verse".to_string(),
+                    },
+                    DrumSequenceItem {
+                        repeat: 1,
+                        pattern: "fill-1".to_string(),
+                    },
+                ]),
+            }),
+        }];
+
+        let seq = strudel_sequence_of_song(&structure, 120);
+        assert_eq!(seq.sequence.len(), 1);
+
+        // Should be a Group of 2 groups (one per row), each with 2 bars
+        fn collect_pattern_names(item: &EBarSequence) -> Vec<String> {
+            match item {
+                EBarSequence::Single(bar) => vec![bar.pattern_name.clone()],
+                EBarSequence::Group(items) => {
+                    items.iter().flat_map(collect_pattern_names).collect()
+                }
+                EBarSequence::RepeatBar(_, bar) => vec![bar.pattern_name.clone()],
+                EBarSequence::RepeatGroup(_, items) => {
+                    items.iter().flat_map(collect_pattern_names).collect()
+                }
+            }
+        }
+
+        let names = collect_pattern_names(&seq.sequence[0].item);
+        assert_eq!(
+            names,
+            vec!["rock-intro", "rock-verse", "rock-verse", "fill-1"]
+        );
+    }
+}

--- a/band-songbook/src/lib.rs
+++ b/band-songbook/src/lib.rs
@@ -12,7 +12,7 @@ pub use nodes::PdfFile;
 use model::{SectionItem, Song};
 use nodes::{PdfCopyFile, SongYml, TexFile};
 use object_store::ObjectStoreExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub use yamake::model::G;
 use yamake::model::GNode;
@@ -56,6 +56,7 @@ pub fn make_all(
     sandbox: &Path,
     settings_path: Option<&Path>,
     pattern: Option<&str>,
+    drum_patterns_dirs: &[PathBuf],
 ) -> (bool, G) {
     let songs = discover(srcdir);
     let songs_sandbox = sandbox.join("songs");
@@ -111,24 +112,26 @@ pub fn make_all(
 
         let parent_dir = rel_path.parent().unwrap_or(Path::new(""));
 
-        // Read song.yml to get structure for lyrics files
-        let song: Option<Song> = std::fs::read_to_string(&song_path)
+        // Read song.yml
+        let song: Song = match std::fs::read_to_string(&song_path)
             .ok()
-            .and_then(|content| serde_yaml::from_str(&content).ok());
+            .and_then(|content| serde_yaml::from_str(&content).ok())
+        {
+            Some(s) => s,
+            None => continue,
+        };
 
         // Filter by pattern if provided (fuzzy match against author + title)
         if let Some(pat) = pattern {
-            let matches = song.as_ref().is_some_and(|s| {
-                let search_str = format!("{} {}", s.info.author, s.info.title).to_lowercase();
-                fuzzy_match(&search_str, &pat.to_lowercase())
-            });
-            if !matches {
+            let search_str = format!("{} {}", song.info.author, song.info.title).to_lowercase();
+            if !fuzzy_match(&search_str, &pat.to_lowercase()) {
                 continue;
             }
         }
 
         // Create SongYml node
-        let song_node = SongYml::new(rel_path.clone());
+        let song_node = SongYml::new(rel_path.clone(), song.clone())
+            .with_drum_patterns_dirs(drum_patterns_dirs.to_vec());
         let song_idx = match g.add_root_node(song_node) {
             Ok(idx) => idx,
             Err(_) => continue,
@@ -140,17 +143,14 @@ pub fn make_all(
         let _ = g.add_root_node(body_node);
 
         // Add lyrics files as root nodes for each Chords and Ref section
-        if let Some(ref song_data) = song {
-            for item in &song_data.structure {
-                match &item.item {
-                    SectionItem::Chords(_) | SectionItem::Ref(_) => {
-                        let lyrics_path =
-                            parent_dir.join("lyrics").join(format!("{}.tex", item.id));
-                        let lyrics_node = TexFile::new(lyrics_path);
-                        let _ = g.add_root_node(lyrics_node);
-                    }
-                    _ => {}
+        for item in &song.structure {
+            match &item.item {
+                SectionItem::Chords(_) | SectionItem::Ref(_) => {
+                    let lyrics_path = parent_dir.join("lyrics").join(format!("{}.tex", item.id));
+                    let lyrics_node = TexFile::new(lyrics_path);
+                    let _ = g.add_root_node(lyrics_node);
                 }
+                _ => {}
             }
         }
 
@@ -165,30 +165,28 @@ pub fn make_all(
         g.add_edge(song_idx, pdf_idx);
 
         // Create PdfCopyFile node to copy the PDF to ../pdf/<author>--@--<title>.pdf
-        if let Some(ref song_data) = song {
-            let pdf_copy_path =
-                Path::new("../pdf").join(format!("{}.pdf", song_data.info.pdf_name_of_song()));
-            let pdf_copy_node = PdfCopyFile::new(pdf_copy_path);
-            if let Ok(pdf_copy_idx) = g.add_node(pdf_copy_node) {
-                g.add_edge(pdf_idx, pdf_copy_idx);
-            }
+        let pdf_copy_path =
+            Path::new("../pdf").join(format!("{}.pdf", song.info.pdf_name_of_song()));
+        let pdf_copy_node = PdfCopyFile::new(pdf_copy_path);
+        if let Ok(pdf_copy_idx) = g.add_node(pdf_copy_node) {
+            g.add_edge(pdf_idx, pdf_copy_idx);
+        }
 
-            // Create lyrics PdfFile nodes (1-column and 2-column)
-            for (filename, delivery_dir) in [
-                ("main-1col.pdf", "pdf-lyrics-1-column"),
-                ("main-2col.pdf", "pdf-lyrics-2-column"),
-            ] {
-                let lyrics_pdf_path = parent_dir.join("lyrics").join(filename);
-                let lyrics_pdf_node = PdfFile::new(lyrics_pdf_path.clone());
-                if let Ok(lyrics_pdf_idx) = g.add_node(lyrics_pdf_node) {
-                    g.add_edge(song_idx, lyrics_pdf_idx);
+        // Create lyrics PdfFile nodes (1-column and 2-column)
+        for (filename, delivery_dir) in [
+            ("main-1col.pdf", "pdf-lyrics-1-column"),
+            ("main-2col.pdf", "pdf-lyrics-2-column"),
+        ] {
+            let lyrics_pdf_path = parent_dir.join("lyrics").join(filename);
+            let lyrics_pdf_node = PdfFile::new(lyrics_pdf_path.clone());
+            if let Ok(lyrics_pdf_idx) = g.add_node(lyrics_pdf_node) {
+                g.add_edge(song_idx, lyrics_pdf_idx);
 
-                    let lyrics_copy_path = Path::new(&format!("../{delivery_dir}"))
-                        .join(format!("{}-lyrics.pdf", song_data.info.pdf_name_of_song()));
-                    let lyrics_copy_node = PdfCopyFile::new(lyrics_copy_path);
-                    if let Ok(lyrics_copy_idx) = g.add_node(lyrics_copy_node) {
-                        g.add_edge(lyrics_pdf_idx, lyrics_copy_idx);
-                    }
+                let lyrics_copy_path = Path::new(&format!("../{delivery_dir}"))
+                    .join(format!("{}-lyrics.pdf", song.info.pdf_name_of_song()));
+                let lyrics_copy_node = PdfCopyFile::new(lyrics_copy_path);
+                if let Ok(lyrics_copy_idx) = g.add_node(lyrics_copy_node) {
+                    g.add_edge(lyrics_pdf_idx, lyrics_copy_idx);
                 }
             }
         }
@@ -234,6 +232,7 @@ pub async fn make_all_with_storage(
     settings: Option<&str>,
     pattern: Option<&str>,
     delivery: &str,
+    drum_patterns_dirs: &[PathBuf],
 ) -> Result<(bool, G), String> {
     use storage::{StoragePath, download_to_local};
 
@@ -304,7 +303,13 @@ pub async fn make_all_with_storage(
     }
 
     // Run the build
-    let (success, g) = make_all(&local_srcdir, sandbox, local_settings.as_deref(), pattern);
+    let (success, g) = make_all(
+        &local_srcdir,
+        sandbox,
+        local_settings.as_deref(),
+        pattern,
+        drum_patterns_dirs,
+    );
 
     // Helper function to collect files recursively
     fn collect_files_recursive(dir: &std::path::Path, files: &mut Vec<std::path::PathBuf>) {

--- a/band-songbook/src/main.rs
+++ b/band-songbook/src/main.rs
@@ -24,10 +24,21 @@ struct Args {
     /// delivery directory for final files (local path or s3://bucket/prefix)
     #[argh(option, short = 'd')]
     delivery: String,
+
+    /// directory containing drum pattern YAML files (can be repeated)
+    #[argh(option)]
+    drum_patterns_dir: Vec<String>,
 }
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[tokio::main]
 async fn main() -> ExitCode {
+    if std::env::args().any(|a| a == "--version" || a == "-V") {
+        println!("band-songbook {VERSION}");
+        return ExitCode::SUCCESS;
+    }
+
     env_logger::init();
     let args: Args = argh::from_env();
 
@@ -42,12 +53,18 @@ async fn main() -> ExitCode {
         return ExitCode::from(1);
     }
 
+    let drum_patterns_dirs: Vec<std::path::PathBuf> = args
+        .drum_patterns_dir
+        .iter()
+        .map(std::path::PathBuf::from)
+        .collect();
     let result: Result<(bool, band_songbook::G), String> = make_all_with_storage(
         &args.srcdir,
         &sandbox,
         Some(args.settings.as_str()),
         args.pattern.as_deref(),
         &args.delivery,
+        &drum_patterns_dirs,
     )
     .await;
 

--- a/band-songbook/src/main_lambda.rs
+++ b/band-songbook/src/main_lambda.rs
@@ -34,6 +34,7 @@ async fn function_handler(event: LambdaEvent<Request>) -> Result<Response, Error
         Some(req.settings.as_str()),
         None, // no pattern filter
         &req.delivery,
+        &[], // no drum patterns dirs
     )
     .await
     {

--- a/band-songbook/src/model.rs
+++ b/band-songbook/src/model.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Song {
     pub files: SongFiles,
     pub info: SongInfo,
@@ -8,7 +8,7 @@ pub struct Song {
     pub structure: Vec<StructureItem>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SongFiles {
     #[serde(default)]
     pub lilypond: Vec<String>,
@@ -18,7 +18,7 @@ pub struct SongFiles {
     pub wav: Vec<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SongInfo {
     pub title: String,
     pub author: String,
@@ -48,19 +48,19 @@ impl SongInfo {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SongMeta {
     pub date: Option<String>,
     pub digest: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StructureItem {
     pub id: String,
     pub item: SectionItem,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum SectionItem {
     Chords(ChordsSection),
     Ref(RefSection),
@@ -68,7 +68,7 @@ pub enum SectionItem {
     NewColumn,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ChordsSection {
     pub title: String,
     #[serde(rename = "type")]
@@ -76,9 +76,18 @@ pub struct ChordsSection {
     pub section_body: Option<String>,
     pub color: Option<String>,
     pub rows: Vec<String>,
+    pub drum_sequence: Option<DrumSequence>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DrumSequenceItem {
+    pub repeat: u32,
+    pub pattern: String,
+}
+
+pub type DrumSequence = Vec<DrumSequenceItem>;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RefSection {
     pub title: String,
     #[serde(rename = "type")]

--- a/band-songbook/src/nodes/mod.rs
+++ b/band-songbook/src/nodes/mod.rs
@@ -4,6 +4,7 @@ pub mod pdf;
 pub mod pdfcopyfile;
 pub mod songtikz;
 pub mod songyml;
+pub mod strudel;
 pub mod tex;
 pub mod texoflilypond;
 
@@ -13,5 +14,6 @@ pub use pdf::PdfFile;
 pub use pdfcopyfile::PdfCopyFile;
 pub use songtikz::SongTikz;
 pub use songyml::SongYml;
+pub use strudel::StrudelFile;
 pub use tex::TexFile;
 pub use texoflilypond::TexOfLilypond;

--- a/band-songbook/src/nodes/songyml.rs
+++ b/band-songbook/src/nodes/songyml.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use yamake::model::{Edge, ExpandError, ExpandResult, GNode, GRootNode};
 
-use super::{LilypondFile, LyTexFile, PdfFile, SongTikz, TexFile, TexOfLilypond};
+use super::{LilypondFile, LyTexFile, PdfFile, SongTikz, StrudelFile, TexFile, TexOfLilypond};
 use crate::chords::bar_numbering::barcount_map_of_structure;
 use crate::helpers::register_helpers;
 use crate::model::{SectionItem, Song};
@@ -21,11 +21,22 @@ const MAIN_LYRICS_2COL_TEMPLATE: &str = include_str!("../resources/texfiles/main
 
 pub struct SongYml {
     pub path: PathBuf,
+    pub song: Song,
+    pub drum_patterns_dirs: Vec<PathBuf>,
 }
 
 impl SongYml {
-    pub fn new(path: PathBuf) -> Self {
-        Self { path }
+    pub fn new(path: PathBuf, song: Song) -> Self {
+        Self {
+            path,
+            song,
+            drum_patterns_dirs: vec![],
+        }
+    }
+
+    pub fn with_drum_patterns_dirs(mut self, dirs: Vec<PathBuf>) -> Self {
+        self.drum_patterns_dirs = dirs;
+        self
     }
 }
 
@@ -42,21 +53,7 @@ impl GRootNode for SongYml {
         // Get the directory containing song.yml
         let parent_dir = self.path.parent().unwrap_or(Path::new(""));
 
-        // Read the song.yml file to get song data (needed for main.tex and templates)
-        let song_yml_path = sandbox.join(&self.path);
-        let mut song: Song = match std::fs::read_to_string(&song_yml_path) {
-            Ok(content) => match serde_yaml::from_str(&content) {
-                Ok(data) => data,
-                Err(e) => {
-                    log::error!("Failed to parse song.yml: {e}");
-                    return Err(ExpandError::Other(e.to_string()));
-                }
-            },
-            Err(e) => {
-                log::error!("Failed to read song.yml: {e}");
-                return Err(ExpandError::Other(e.to_string()));
-            }
-        };
+        let mut song = self.song.clone();
 
         // Load settings from settings.yml at sandbox root
         let settings = Settings::load(sandbox).map_err(ExpandError::Other)?;
@@ -465,6 +462,18 @@ impl GRootNode for SongYml {
             };
             edges.push(texofly_to_pdf_edge);
         }
+
+        // Create StrudelFile node
+        let strudel_path = parent_dir.join("strudel.html");
+        let libraries = self.drum_patterns_dirs.clone();
+        let strudel_node = StrudelFile::new(strudel_path.clone(), song.clone(), libraries.clone());
+        nodes.push(Box::new(strudel_node));
+
+        // Edge: song.yml -> strudel.html
+        edges.push(Edge {
+            nfrom: Box::new(SongYml::new(self.path.clone(), self.song.clone())),
+            nto: Box::new(StrudelFile::new(strudel_path, song, libraries)),
+        });
 
         Ok((nodes, edges))
     }

--- a/band-songbook/src/nodes/strudel.rs
+++ b/band-songbook/src/nodes/strudel.rs
@@ -1,0 +1,96 @@
+use std::path::{Path, PathBuf};
+use yamake::model::GNode;
+
+use strudel_of_lilypond::sequencer::lilypond::strudel_of_sequence;
+
+use crate::helpers::strudel_sequence_of_song;
+use crate::model::Song;
+
+pub struct StrudelFile {
+    pub path: PathBuf,
+    pub song: Song,
+    pub libraries: Vec<PathBuf>,
+}
+
+impl StrudelFile {
+    pub fn new(path: PathBuf, song: Song, libraries: Vec<PathBuf>) -> Self {
+        Self {
+            path,
+            song,
+            libraries,
+        }
+    }
+}
+
+impl GNode for StrudelFile {
+    fn tag(&self) -> String {
+        "strudel".to_string()
+    }
+
+    fn pathbuf(&self) -> PathBuf {
+        self.path.clone()
+    }
+
+    fn build(&self, sandbox: &Path, _predecessors: &[&(dyn GNode + Send + Sync)]) -> bool {
+        let sequence = strudel_sequence_of_song(&self.song.structure, self.song.info.tempo);
+
+        let dest = sandbox.join(&self.path);
+        if let Some(parent) = dest.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                log::error!(
+                    "Failed to create directory for {}: {}",
+                    self.path.display(),
+                    e
+                );
+                return false;
+            }
+        }
+
+        if sequence.sequence.is_empty() {
+            // Write empty HTML placeholder
+            if let Err(e) = std::fs::write(&dest, "") {
+                log::error!("Failed to write {}: {}", dest.display(), e);
+                return false;
+            }
+            log::info!(
+                "Empty sequence for {}, wrote empty file",
+                self.path.display()
+            );
+            return true;
+        }
+
+        if self.libraries.is_empty() {
+            log::info!("No drum pattern libraries provided, skipping strudel generation");
+            if let Err(e) = std::fs::write(&dest, "") {
+                log::error!("Failed to write {}: {}", dest.display(), e);
+                return false;
+            }
+            return true;
+        }
+
+        let title = &self.song.info.title;
+        let author = &self.song.info.author;
+        let html = match strudel_of_sequence(&sequence, &self.libraries, title) {
+            Ok(h) => {
+                let header = format!("// author : {author}\n// title : {title}\n");
+                h.replacen("<!--\n", &format!("<!--\n{header}"), 1)
+            }
+            Err(e) => {
+                log::error!(
+                    "Failed to generate strudel for {}: {}",
+                    self.path.display(),
+                    e
+                );
+                return false;
+            }
+        };
+
+        if let Err(e) = std::fs::write(&dest, &html) {
+            log::error!("Failed to write {}: {}", dest.display(), e);
+            return false;
+        }
+
+        log::info!("Wrote strudel HTML to {}", dest.display());
+        true
+    }
+}

--- a/band-songbook/src/tests.rs
+++ b/band-songbook/src/tests.rs
@@ -29,7 +29,11 @@ fn test_yamake_build_song() {
     let _ = g.add_root_node(colors_node);
 
     // SongYml is a root node (source file)
-    let song_node = SongYml::new(PathBuf::from("PJHarvey/Dress/song.yml"));
+    let song: Song = serde_yaml::from_str(
+        &std::fs::read_to_string("tests/data/PJHarvey/Dress/song.yml").unwrap(),
+    )
+    .unwrap();
+    let song_node = SongYml::new(PathBuf::from("PJHarvey/Dress/song.yml"), song);
     let song_idx = g.add_root_node(song_node).expect("Failed to add song node");
 
     // body.tex is a root node (source file from srcdir)
@@ -74,7 +78,11 @@ fn test_yamake_build_song_with_lilypond() {
     let _ = g.add_root_node(colors_node);
 
     // mademoiselle_K/ca_me_vexe - has lilypond files
-    let song_node = SongYml::new(PathBuf::from("mademoiselle_K/ca_me_vexe/song.yml"));
+    let song: Song = serde_yaml::from_str(
+        &std::fs::read_to_string("tests/data/mademoiselle_K/ca_me_vexe/song.yml").unwrap(),
+    )
+    .unwrap();
+    let song_node = SongYml::new(PathBuf::from("mademoiselle_K/ca_me_vexe/song.yml"), song);
     let song_idx = g.add_root_node(song_node).expect("Failed to add song node");
 
     let body_node = TexFile::new(PathBuf::from("mademoiselle_K/ca_me_vexe/body.tex"));
@@ -200,6 +208,7 @@ fn test_make_all() {
         sandbox.path(),
         Some(Path::new("tests/data/settings.yml")),
         None,
+        &[],
     );
     assert!(success, "make_all should succeed");
 
@@ -374,6 +383,7 @@ fn test_make_all_with_pattern() {
         sandbox.path(),
         Some(Path::new("tests/data/settings.yml")),
         Some("madkvex"),
+        &[],
     );
     assert!(success, "make_all with pattern should succeed");
 
@@ -419,8 +429,15 @@ async fn test_make_all_with_storage_local() {
     let delivery = tempfile::tempdir().expect("Failed to create delivery dir");
     let delivery_path = delivery.path().to_str().unwrap();
 
-    let result =
-        make_all_with_storage(srcdir, sandbox.path(), Some(settings), None, delivery_path).await;
+    let result = make_all_with_storage(
+        srcdir,
+        sandbox.path(),
+        Some(settings),
+        None,
+        delivery_path,
+        &[],
+    )
+    .await;
 
     assert!(result.is_ok(), "make_all_with_storage should succeed");
     let (success, _g) = result.unwrap();
@@ -455,7 +472,7 @@ async fn test_make_all_with_s3() {
     let sandbox = tempfile::tempdir().expect("Failed to create temp dir");
 
     let result =
-        make_all_with_storage(srcdir, sandbox.path(), Some(settings), None, delivery).await;
+        make_all_with_storage(srcdir, sandbox.path(), Some(settings), None, delivery, &[]).await;
 
     match &result {
         Ok((success, _g)) => {

--- a/band-songbook/tests/data/mademoiselle_K/ca_me_vexe/song.yml
+++ b/band-songbook/tests/data/mademoiselle_K/ca_me_vexe/song.yml
@@ -24,6 +24,9 @@ structure:
       rows:
         - Em|Em|Em|G
         - Em|G|C7|G
+      drum_sequence:
+        - repeat: 8
+          pattern: cymr
   - id: couplet1
     item: !Chords
       title: couplet 1


### PR DESCRIPTION
## Summary
- Add `StrudelFile` build node that generates interactive Strudel HTML files from song drum patterns using the `strudel-of-lilypond` crate
- Add `DrumSequence` model with per-section pattern names and repeat counts in `song.yml`
- Add `--drum-patterns-dir` CLI option for specifying drum pattern library directories
- Refactor `SongYml` to receive `Song` via constructor instead of reading from disk in `expand()`
- Switch `yamake` and `strudel-of-lilypond` dependencies to crates.io releases

## Test plan
- [x] All 29 unit tests pass (`cargo test --lib`)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt` applied
- [x] `make clean run` succeeds with `BF:0`
- [x] Generated `strudel.html` opens in browser with interactive Strudel player
- [x] Drum sequence from `song.yml` correctly maps pattern names to bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)