### PR TITLE
Add doc comments and pattern filter to lambda

### DIFF
--- a/band-songbook/src/chords/glyph.rs
+++ b/band-songbook/src/chords/glyph.rs
@@ -1,5 +1,6 @@
 use super::model::{Accidental, Alteration, BarItem};
 
+/// Renders a [`BarItem`] as a display string for TikZ chord charts.
 pub fn glyph_of_baritem(item: &BarItem) -> String {
     match item {
         BarItem::Chord(chord) => {

--- a/band-songbook/src/chords/mod.rs
+++ b/band-songbook/src/chords/mod.rs
@@ -1,4 +1,8 @@
+/// Bar numbering across song sections.
 pub mod bar_numbering;
+/// Chord-to-glyph rendering for TikZ output.
 pub mod glyph;
+/// Data types for chords, bars, and parsed rows.
 pub mod model;
+/// Parser for chord row strings (e.g. `"Am|G|C|x2"`).
 pub mod parse;

--- a/band-songbook/src/helpers/mod.rs
+++ b/band-songbook/src/helpers/mod.rs
@@ -1,4 +1,6 @@
+/// Handlebars template helper functions for LaTeX generation.
 pub mod handlebar_helpers;
+/// Conversion from song structure to Strudel bar sequences.
 pub mod sequence;
 
 pub use handlebar_helpers::register_helpers;

--- a/band-songbook/src/lib.rs
+++ b/band-songbook/src/lib.rs
@@ -1,9 +1,16 @@
+/// Chord parsing, bar numbering, and glyph rendering.
 pub mod chords;
+/// Song discovery by scanning directories for `song.yml` files.
 pub mod discover;
+/// Handlebars template helpers and song-to-sequence conversion.
 pub mod helpers;
+/// Data model for songs, sections, chords, and drum sequences.
 pub mod model;
+/// Build graph nodes for the yamake dependency system.
 pub mod nodes;
+/// Build settings loaded from `settings.yml`.
 pub mod settings;
+/// S3 and local filesystem storage operations.
 pub mod storage;
 
 pub use discover::discover;

--- a/band-songbook/src/main_lambda.rs
+++ b/band-songbook/src/main_lambda.rs
@@ -7,6 +7,7 @@ struct Request {
     srcdir: String,
     settings: String,
     delivery: String,
+    pattern: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -32,7 +33,7 @@ async fn function_handler(event: LambdaEvent<Request>) -> Result<Response, Error
         &req.srcdir,
         sandbox,
         Some(req.settings.as_str()),
-        None, // no pattern filter
+        req.pattern.as_deref(),
         &req.delivery,
         &[], // no drum patterns dirs
     )

--- a/band-songbook/src/model.rs
+++ b/band-songbook/src/model.rs
@@ -1,34 +1,48 @@
 use serde::{Deserialize, Serialize};
 
+/// A complete song definition, deserialized from `song.yml`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Song {
+    /// Source files (LilyPond, TeX, WAV) associated with this song.
     pub files: SongFiles,
+    /// Title, author, tempo, and time signature.
     pub info: SongInfo,
+    /// Optional metadata such as date and content digest.
     pub meta: SongMeta,
+    /// Ordered list of sections that make up the song structure.
     pub structure: Vec<StructureItem>,
 }
 
+/// Source file references for a song.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SongFiles {
+    /// LilyPond notation files (`.ly`).
     #[serde(default)]
     pub lilypond: Vec<String>,
+    /// LaTeX source files (`.tex`).
     #[serde(default)]
     pub tex: Vec<String>,
+    /// Audio files (`.wav`).
     #[serde(default)]
     pub wav: Vec<String>,
 }
 
+/// Core song metadata: title, author, tempo, and time signature.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SongInfo {
+    /// Song title.
     pub title: String,
+    /// Song author or band name.
     pub author: String,
+    /// Tempo in beats per minute.
     pub tempo: u16,
+    /// Time signature (e.g. `"4/4"`), if specified.
     pub time_signature: Option<String>,
 }
 
 impl SongInfo {
     /// Returns a normalized PDF filename based on author and title.
-    /// Format: "<author>--@--<title>"
+    /// Format: `{author}--@--{title}`
     /// - Capitals are replaced with lowercase
     /// - All characters which are not A-Za-z0-9 are replaced with '_'
     pub fn pdf_name_of_song(&self) -> String {
@@ -48,51 +62,79 @@ impl SongInfo {
     }
 }
 
+/// Optional metadata for a song (date, content digest).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SongMeta {
+    /// Date the song was added or last modified.
     pub date: Option<String>,
+    /// MD5 digest of the song content for change detection.
     pub digest: Option<String>,
 }
 
+/// A named section in the song structure.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StructureItem {
+    /// Unique identifier for this section (e.g. `"intro"`, `"couplet1"`).
     pub id: String,
+    /// The section content.
     pub item: SectionItem,
 }
 
+/// The different kinds of sections that can appear in a song structure.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum SectionItem {
+    /// A section with chord rows.
     Chords(ChordsSection),
+    /// A reference to another section (shares its chord content).
     Ref(RefSection),
+    /// A horizontal rule with a given width percentage.
     HRule(u32),
+    /// A column break in multi-column layouts.
     NewColumn,
 }
 
+/// A section containing chord rows and optional drum patterns.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ChordsSection {
+    /// Display title for this section.
     pub title: String,
+    /// Section type (e.g. `"intro"`, `"couplet"`, `"refrain"`).
     #[serde(rename = "type")]
     pub section_type: String,
+    /// Optional body text displayed below the section header.
     pub section_body: Option<String>,
+    /// Background color name (X11 color).
     pub color: Option<String>,
+    /// Chord rows, each in `"A|Bm|C#|x2"` format.
     pub rows: Vec<String>,
+    /// Optional drum pattern sequence for Strudel generation.
     pub drum_sequence: Option<DrumSequence>,
 }
 
+/// A single item in a drum sequence: a pattern name repeated N times.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DrumSequenceItem {
+    /// Number of consecutive bars using this pattern.
     pub repeat: u32,
+    /// Name of the drum pattern (must exist in a library directory).
     pub pattern: String,
 }
 
+/// A sequence of drum pattern items for a section.
 pub type DrumSequence = Vec<DrumSequenceItem>;
 
+/// A section that references another section's chord content.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RefSection {
+    /// Display title for this reference section.
     pub title: String,
+    /// Optional override of the section type.
     #[serde(rename = "type")]
     pub section_type: Option<String>,
+    /// Optional body text.
     pub section_body: Option<String>,
+    /// Background color name (X11 color).
     pub color: Option<String>,
+    /// ID of the [`ChordsSection`] this references.
     pub link: String,
 }

--- a/band-songbook/src/nodes/lilypond.rs
+++ b/band-songbook/src/nodes/lilypond.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use yamake::model::GRootNode;
 
+/// Root node representing a LilyPond source file (`.ly`).
 pub struct LilypondFile {
     pub path: PathBuf,
 }

--- a/band-songbook/src/nodes/lytex.rs
+++ b/band-songbook/src/nodes/lytex.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use yamake::model::GNode;
 
+/// Build node for a `.lytex` file (LilyPond embedded in LaTeX).
 pub struct LyTexFile {
     pub path: PathBuf,
 }

--- a/band-songbook/src/nodes/mod.rs
+++ b/band-songbook/src/nodes/mod.rs
@@ -1,11 +1,20 @@
+/// LilyPond source file node (`.ly`).
 pub mod lilypond;
+/// LilyPond-to-TeX intermediate file node (`.lytex`).
 pub mod lytex;
+/// PDF output node, built by running `lualatex`.
 pub mod pdf;
+/// Node that copies a built PDF to the delivery directory.
 pub mod pdfcopyfile;
+/// TikZ chord chart node (`song.tikz`).
 pub mod songtikz;
+/// Song root node that expands `song.yml` into the build graph.
 pub mod songyml;
+/// Strudel HTML node with interactive drum patterns.
 pub mod strudel;
+/// LaTeX source file node (`.tex`).
 pub mod tex;
+/// TeX output from LilyPond compilation.
 pub mod texoflilypond;
 
 pub use lilypond::LilypondFile;

--- a/band-songbook/src/nodes/pdf.rs
+++ b/band-songbook/src/nodes/pdf.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use yamake::model::GNode;
 
+/// Build node that compiles a `.tex` file into a PDF using `lualatex`.
 pub struct PdfFile {
     pub path: PathBuf,
 }

--- a/band-songbook/src/nodes/pdfcopyfile.rs
+++ b/band-songbook/src/nodes/pdfcopyfile.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use yamake::model::GNode;
 
+/// Build node that copies a PDF to the delivery directory.
 pub struct PdfCopyFile {
     pub path: PathBuf,
 }

--- a/band-songbook/src/nodes/songtikz.rs
+++ b/band-songbook/src/nodes/songtikz.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use yamake::model::GNode;
 
+/// Build node for the TikZ chord chart (`song.tikz`).
 pub struct SongTikz {
     pub path: PathBuf,
 }

--- a/band-songbook/src/nodes/songyml.rs
+++ b/band-songbook/src/nodes/songyml.rs
@@ -19,13 +19,19 @@ const MACROS_LY_TEMPLATE: &str = include_str!("../resources/lyfiles/macros.ly");
 const MAIN_LYRICS_1COL_TEMPLATE: &str = include_str!("../resources/texfiles/main-lyrics-1col.tex");
 const MAIN_LYRICS_2COL_TEMPLATE: &str = include_str!("../resources/texfiles/main-lyrics-2col.tex");
 
+/// Root node for `song.yml` that expands into the full build graph
+/// (TeX files, PDF, lyrics, LilyPond, and Strudel nodes).
 pub struct SongYml {
+    /// Path to the `song.yml` file relative to srcdir.
     pub path: PathBuf,
+    /// Parsed song data.
     pub song: Song,
+    /// Directories containing drum pattern library files.
     pub drum_patterns_dirs: Vec<PathBuf>,
 }
 
 impl SongYml {
+    /// Creates a new `SongYml` node with the given path and song data.
     pub fn new(path: PathBuf, song: Song) -> Self {
         Self {
             path,
@@ -34,6 +40,7 @@ impl SongYml {
         }
     }
 
+    /// Sets the drum pattern library directories (builder pattern).
     pub fn with_drum_patterns_dirs(mut self, dirs: Vec<PathBuf>) -> Self {
         self.drum_patterns_dirs = dirs;
         self

--- a/band-songbook/src/nodes/strudel.rs
+++ b/band-songbook/src/nodes/strudel.rs
@@ -6,13 +6,19 @@ use strudel_of_lilypond::sequencer::lilypond::strudel_of_sequence;
 use crate::helpers::strudel_sequence_of_song;
 use crate::model::Song;
 
+/// Build node that generates an interactive Strudel HTML file from
+/// the song's drum pattern sequence.
 pub struct StrudelFile {
+    /// Output path for `strudel.html` relative to the song directory.
     pub path: PathBuf,
+    /// Song data used to derive the bar sequence.
     pub song: Song,
+    /// Drum pattern library directories for resolving pattern names.
     pub libraries: Vec<PathBuf>,
 }
 
 impl StrudelFile {
+    /// Creates a new `StrudelFile` node.
     pub fn new(path: PathBuf, song: Song, libraries: Vec<PathBuf>) -> Self {
         Self {
             path,

--- a/band-songbook/src/nodes/tex.rs
+++ b/band-songbook/src/nodes/tex.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use yamake::model::GRootNode;
 
+/// Root node representing a LaTeX source file (`.tex`).
 pub struct TexFile {
     pub path: PathBuf,
 }

--- a/band-songbook/src/nodes/texoflilypond.rs
+++ b/band-songbook/src/nodes/texoflilypond.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use yamake::model::GNode;
 
+/// Build node for the TeX output produced by LilyPond compilation.
 pub struct TexOfLilypond {
     pub path: PathBuf,
 }

--- a/band-songbook/src/settings.rs
+++ b/band-songbook/src/settings.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::path::Path;
 
+/// Global build settings loaded from `settings.yml`.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct Settings {
     #[serde(default)]


### PR DESCRIPTION
## Summary
- Add `///` doc comments to all public modules, structs, enums, type aliases, and functions (coverage was 24%)
- Add optional `pattern` field to lambda request for song filtering
- Fix HTML tag warning in existing doc comment

## Test plan
- [x] `cargo test --lib` — 29 tests pass
- [x] `cargo doc --no-deps` — builds without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)