### PR TITLE
Add configurable log level to lambda

### DIFF
--- a/band-songbook/src/main_lambda.rs
+++ b/band-songbook/src/main_lambda.rs
@@ -1,6 +1,10 @@
 use band_songbook::make_all_with_storage;
 use lambda_runtime::{Error, LambdaEvent, run, service_fn};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::reload;
 
 #[derive(Deserialize, Debug)]
 struct Request {
@@ -8,6 +12,7 @@ struct Request {
     settings: String,
     delivery: String,
     pattern: Option<String>,
+    log_level: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -17,9 +22,27 @@ struct Response {
     message: String,
 }
 
-async fn function_handler(event: LambdaEvent<Request>) -> Result<Response, Error> {
+fn parse_log_level(level: Option<&str>) -> LevelFilter {
+    match level.map(|s| s.to_lowercase()).as_deref() {
+        Some("trace") => LevelFilter::TRACE,
+        Some("debug") => LevelFilter::DEBUG,
+        Some("info") => LevelFilter::INFO,
+        Some("warn") => LevelFilter::WARN,
+        Some("error") => LevelFilter::ERROR,
+        _ => LevelFilter::INFO,
+    }
+}
+
+async fn function_handler(
+    reload_handle: Arc<reload::Handle<LevelFilter, tracing_subscriber::Registry>>,
+    event: LambdaEvent<Request>,
+) -> Result<Response, Error> {
     let request_id = event.context.request_id.clone();
     let req = event.payload;
+
+    // Update log level if specified in the request
+    let level = parse_log_level(req.log_level.as_deref());
+    reload_handle.reload(level)?;
 
     // Use a fixed path for local sandbox (Lambda only has /tmp writable)
     let sandbox = std::path::Path::new("/tmp/sandbox");
@@ -28,6 +51,7 @@ async fn function_handler(event: LambdaEvent<Request>) -> Result<Response, Error
     log::info!("settings: {}", &req.settings);
     log::info!("delivery: {}", &req.delivery);
     log::info!("sandbox: {}", sandbox.display());
+    log::info!("log_level: {level}");
 
     match make_all_with_storage(
         &req.srcdir,
@@ -65,14 +89,25 @@ async fn function_handler(event: LambdaEvent<Request>) -> Result<Response, Error
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // Initialize logging
-    tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::INFO)
-        .with_target(false)
-        .without_time()
+    // Initialize logging with a reloadable filter so each invocation can set its own level
+    let (filter, reload_handle) = reload::Layer::new(LevelFilter::INFO);
+    let reload_handle = Arc::new(reload_handle);
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_target(false)
+                .without_time(),
+        )
         .init();
 
     log::info!("Starting band-songbook lambda...");
 
-    run(service_fn(function_handler)).await
+    let handle = Arc::clone(&reload_handle);
+    run(service_fn(move |event| {
+        let handle = Arc::clone(&handle);
+        async move { function_handler(handle, event).await }
+    }))
+    .await
 }


### PR DESCRIPTION
## Summary
- Adds optional `log_level` field to the lambda request payload
- Uses `tracing_subscriber::reload` to dynamically update the log level per invocation
- Defaults to `info` if not specified; accepts `trace`, `debug`, `info`, `warn`, `error`

## Test plan
- [x] `cargo check --bin band-songbook-lambda` compiles
- [x] `cargo test --lib` — all 29 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)