### PR TITLE
Switch yamake to crates.io 0.1.11

### DIFF
--- a/band-songbook/Cargo.toml
+++ b/band-songbook/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
-yamake = { path = "../../yamake" }
+yamake = "0.1.11"
 object_store = { version = "0.13", features = ["aws"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 # Pin AWS SDK crates to versions compatible with Rust 1.85


### PR DESCRIPTION
## Summary
- Switch yamake dependency from local path to crates.io v0.1.11

## Test plan
- [x] `cargo test --lib` — all 30 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)