### PR TITLE
Bump version to 0.0.17

### DIFF
--- a/band-songbook/Cargo.toml
+++ b/band-songbook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "band-songbook"
-version = "0.0.16"
+version = "0.0.17"
 edition = "2024"
 description = "Build system for generating PDF songbooks with chord charts and LilyPond music notation"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump crate version from 0.0.16 to 0.0.17

🤖 Generated with [Claude Code](https://claude.com/claude-code)