### PR TITLE
Support S3 drum patterns and fix upload bug

### DIFF
--- a/band-songbook/Makefile
+++ b/band-songbook/Makefile
@@ -1,6 +1,8 @@
 help: ## Show this help
 	@grep -E '^[a-zA-Z0-9_-]+:.*##' $(MAKEFILE_LIST) | awk -F ':.*## ' '{printf "  %-10s %s\n", $$1, $$2}'
 
+s3testpath=s3://zik-laurent/test
+
 clean: ## Remove delivery and sandbox directories
 	rm -rf delivery sandbox
 
@@ -16,12 +18,14 @@ open: ## Open strudel HTML for ca_me_vexe
 	open sandbox/songs/mademoiselle_K/ca_me_vexe/strudel.html
 
 s3: ## Build rasmus song from S3
+	aws s3 rm --recursive $(s3testpath)	
 	cargo run --bin band-songbook -- \
 		--srcdir s3://zik-laurent/songs \
 		--settings s3://zik-laurent/songs/settings.yml \
 		--sandbox sandbox \
-		--delivery delivery \
-		--pattern rasmus
+		--delivery $(s3testpath)/delivery \
+		--pattern rasmus \
+		--drum-patterns-dir s3://zik-laurent/drums
 
 run-all: ## Build songs from local
 	cargo run --bin band-songbook -- \

--- a/band-songbook/src/lib.rs
+++ b/band-songbook/src/lib.rs
@@ -342,6 +342,26 @@ pub async fn make_all_with_storage(
         _temp_settings = None;
     }
 
+    // Handle drum pattern directories - download from S3 if needed
+    let mut _temp_drum_dirs: Vec<tempfile::TempDir> = Vec::new();
+    let mut local_drum_dirs: Vec<PathBuf> = Vec::new();
+
+    for dir in drum_patterns_dirs {
+        let dir_str = dir.to_string_lossy();
+        let dp = StoragePath::parse(&dir_str)?;
+        if dp.is_s3() {
+            let temp = tempfile::tempdir()
+                .map_err(|e| format!("Failed to create temp drum patterns dir: {e}"))?;
+            let local_path = temp.path().to_path_buf();
+            log::info!("Downloading drum patterns from {dir_str} to {local_path:?}");
+            download_to_local(&dp, &local_path).await?;
+            local_drum_dirs.push(local_path);
+            _temp_drum_dirs.push(temp);
+        } else {
+            local_drum_dirs.push(dir.clone());
+        }
+    }
+
     // Build the world and run the build
     let world = world_of_srcdir(&local_srcdir);
     let (success, g) = make_all(
@@ -349,7 +369,7 @@ pub async fn make_all_with_storage(
         sandbox,
         local_settings.as_deref(),
         pattern,
-        drum_patterns_dirs,
+        &local_drum_dirs,
         &world,
     );
 

--- a/band-songbook/src/storage.rs
+++ b/band-songbook/src/storage.rs
@@ -195,11 +195,10 @@ pub async fn upload_paths_to_s3(
     // Collect all files to upload (expand directories)
     let mut files_to_upload = Vec::new();
     for path in paths {
-        let full_path = base_dir.join(path);
-        if full_path.is_dir() {
-            files_to_upload.extend(walkdir(&full_path)?);
-        } else if full_path.is_file() {
-            files_to_upload.push(full_path);
+        if path.is_dir() {
+            files_to_upload.extend(walkdir(path)?);
+        } else if path.is_file() {
+            files_to_upload.push(path.clone());
         }
     }
 


### PR DESCRIPTION
## Summary
- Download drum pattern directories from S3 to local temp dirs before building, so `--drum-patterns-dir s3://...` works
- Fix `upload_paths_to_s3` which double-joined already-absolute paths with `base_dir`, causing 0 files to be uploaded to S3
- Update Makefile `s3` target to deliver to S3 and include `--drum-patterns-dir`

## Test plan
- [x] `cargo test --lib` — 30 tests pass
- [x] `make clean s3` — builds rasmus song with S3 drum patterns, strudel HTML is 4.4KB (was 0 bytes)
- [x] S3 delivery verified: pdf, lyrics, and tempo files all uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)