### PR TITLE
Rename has_song to has_mp3

### DIFF
--- a/band-songbook/Cargo.toml
+++ b/band-songbook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "band-songbook"
-version = "0.0.22"
+version = "0.0.23"
 edition = "2024"
 description = "Build system for generating PDF songbooks with chord charts and LilyPond music notation"
 license = "MIT"

--- a/band-songbook/src/model.rs
+++ b/band-songbook/src/model.rs
@@ -32,7 +32,7 @@ pub struct SongFiles {
     pub has_clicks: bool,
     /// Whether this song has a song recording (`song.mp3`).
     #[serde(default)]
-    pub has_song: bool,
+    pub has_mp3: bool,
 }
 
 /// Core song metadata: title, author, tempo, and time signature.

--- a/band-songbook/src/nodes/songyml.rs
+++ b/band-songbook/src/nodes/songyml.rs
@@ -502,9 +502,9 @@ impl GRootNode for SongYml {
         });
 
         // Mount click-related nodes if has_clicks is true
-        if self.song.files.has_clicks && !self.song.files.has_song {
+        if self.song.files.has_clicks && !self.song.files.has_mp3 {
             return Err(ExpandError::Other(format!(
-                "{}: has_clicks is true but has_song is false — song.mp3 is required for click overlay",
+                "{}: has_clicks is true but has_mp3 is false — song.mp3 is required for click overlay",
                 self.path.display()
             )));
         }
@@ -533,8 +533,8 @@ impl GRootNode for SongYml {
             });
         }
 
-        // Mount song.mp3 if has_song is true
-        if self.song.files.has_song {
+        // Mount song.mp3 if has_mp3 is true
+        if self.song.files.has_mp3 {
             let song_mp3_path = parent_dir.join("song.mp3");
             nodes.push(Box::new(Mp3::new(song_mp3_path)));
         }

--- a/band-songbook/src/tests.rs
+++ b/band-songbook/src/tests.rs
@@ -521,8 +521,8 @@ async fn test_make_all_with_storage_local() {
 }
 
 #[test]
-fn test_make_all_has_clicks_and_has_song() {
-    // Create a temp srcdir with a song that has both has_clicks and has_song
+fn test_make_all_has_clicks_and_has_mp3() {
+    // Create a temp srcdir with a song that has both has_clicks and has_mp3
     let srcdir = tempfile::tempdir().expect("Failed to create srcdir");
     let song_dir = srcdir.path().join("TestArtist/ClickSong");
     std::fs::create_dir_all(&song_dir).expect("create song dir");
@@ -535,7 +535,7 @@ files:
   tex: []
   wav: []
   has_clicks: true
-  has_song: true
+  has_mp3: true
 info:
   title: Click Song
   author: Test Artist

--- a/band-songbook/tests/data/mademoiselle_K/ca_me_vexe/song.yml
+++ b/band-songbook/tests/data/mademoiselle_K/ca_me_vexe/song.yml
@@ -8,7 +8,7 @@ files:
     - body.tex
   wav: []
   has_clicks: true
-  has_song: true
+  has_mp3: true
 info:
   title: Ca me vexe
   author: Mademoiselle K


### PR DESCRIPTION
## Summary
- Rename `has_song` to `has_mp3` for clarity — describes the file type, not the concept
- Bump version to 0.0.23

## Test plan
- [x] 36 lib tests pass
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)