### PR TITLE
Add ffmpeg to CI dependencies

### DIFF
--- a/.github/workflows/publish-band-songbook.yml
+++ b/.github/workflows/publish-band-songbook.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install LaTeX and LilyPond
         run: |
           sudo apt-get update
-          sudo apt-get install -y texlive-luatex texlive-latex-extra lilypond
+          sudo apt-get install -y texlive-luatex texlive-latex-extra lilypond ffmpeg
 
       - name: Cache cargo registry
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- Add `ffmpeg` to apt-get install in CI workflow so `test_click_check_mp3_build` passes

## Test plan
- [x] CI should now pass the click overlay test

🤖 Generated with [Claude Code](https://claude.com/claude-code)