### PR TITLE
Add mp3, mp3-with-clicks, and clicks delivery directories

### DIFF
--- a/band-songbook/Cargo.toml
+++ b/band-songbook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "band-songbook"
-version = "0.0.23"
+version = "0.0.24"
 edition = "2024"
 description = "Build system for generating PDF songbooks with chord charts and LilyPond music notation"
 license = "MIT"

--- a/band-songbook/src/lib.rs
+++ b/band-songbook/src/lib.rs
@@ -163,9 +163,16 @@ pub fn make_all(
     }
 
     // Create pdf-lyrics directories for copied lyrics PDFs (1-column and 2-column)
-    for dir in ["pdf-lyrics-1-column", "pdf-lyrics-2-column"] {
-        let pdf_lyrics_dir = sandbox.join(dir);
-        if let Err(e) = std::fs::create_dir_all(&pdf_lyrics_dir) {
+    // and mp3/clicks directories for audio delivery
+    for dir in [
+        "pdf-lyrics-1-column",
+        "pdf-lyrics-2-column",
+        "mp3",
+        "mp3-with-clicks",
+        "clicks",
+    ] {
+        let sub_dir = sandbox.join(dir);
+        if let Err(e) = std::fs::create_dir_all(&sub_dir) {
             log::error!("Failed to create {dir} directory: {e}");
         }
     }
@@ -427,7 +434,14 @@ pub async fn make_all_with_storage(
             collect_files_recursive(&pdf_dir, &mut delivery_files);
         }
 
-        for dir in ["pdf-lyrics-1-column", "pdf-lyrics-2-column", "tempo"] {
+        for dir in [
+            "pdf-lyrics-1-column",
+            "pdf-lyrics-2-column",
+            "tempo",
+            "mp3",
+            "mp3-with-clicks",
+            "clicks",
+        ] {
             let sub_dir = sandbox.join(dir);
             if sub_dir.exists() {
                 collect_files_recursive(&sub_dir, &mut delivery_files);
@@ -444,7 +458,15 @@ pub async fn make_all_with_storage(
         std::fs::create_dir_all(local_delivery)
             .map_err(|e| format!("Failed to create delivery directory: {e}"))?;
 
-        for subdir in &["pdf", "pdf-lyrics-1-column", "pdf-lyrics-2-column", "tempo"] {
+        for subdir in &[
+            "pdf",
+            "pdf-lyrics-1-column",
+            "pdf-lyrics-2-column",
+            "tempo",
+            "mp3",
+            "mp3-with-clicks",
+            "clicks",
+        ] {
             let src_dir = sandbox.join(subdir);
             if !src_dir.exists() {
                 continue;

--- a/band-songbook/src/nodes/songyml.rs
+++ b/band-songbook/src/nodes/songyml.rs
@@ -473,6 +473,9 @@ impl GRootNode for SongYml {
             edges.push(texofly_to_pdf_edge);
         }
 
+        // Pre-compute file stem for delivery copy nodes (before song is moved)
+        let file_stem = song.info.file_stem_of_song();
+
         // Create StrudelFile node
         let strudel_path = parent_dir.join("strudel.html");
         let libraries = self.drum_patterns_dirs.clone();
@@ -490,8 +493,7 @@ impl GRootNode for SongYml {
         });
 
         // Create CopyFile node to copy strudel.html to ../tempo/<author>--@--<title>.html
-        let strudel_copy_path =
-            Path::new("../tempo").join(format!("{}.html", song.info.file_stem_of_song()));
+        let strudel_copy_path = Path::new("../tempo").join(format!("{}.html", file_stem));
         let strudel_copy_node = CopyFile::new(strudel_copy_path.clone(), "strudel".to_string());
         nodes.push(Box::new(strudel_copy_node));
 
@@ -520,7 +522,7 @@ impl GRootNode for SongYml {
             // Edge: clicks.yml -> song-with-click.mp3
             edges.push(Edge {
                 nfrom: Box::new(
-                    ClickYml::new(clicks_yml_path, sandbox).map_err(ExpandError::Other)?,
+                    ClickYml::new(clicks_yml_path.clone(), sandbox).map_err(ExpandError::Other)?,
                 ),
                 nto: Box::new(ClickCheckMp3::new(check_mp3_path.clone())),
             });
@@ -529,14 +531,52 @@ impl GRootNode for SongYml {
             let song_mp3_path = parent_dir.join("song.mp3");
             edges.push(Edge {
                 nfrom: Box::new(Mp3::new(song_mp3_path)),
-                nto: Box::new(ClickCheckMp3::new(check_mp3_path)),
+                nto: Box::new(ClickCheckMp3::new(check_mp3_path.clone())),
+            });
+
+            // Copy song-with-click.mp3 to ../mp3-with-clicks/<name>.mp3
+            let click_mp3_copy_path =
+                Path::new("../mp3-with-clicks").join(format!("{}-with-clicks.mp3", file_stem));
+            let click_mp3_copy_node =
+                CopyFile::new(click_mp3_copy_path.clone(), "click_check_mp3".to_string());
+            nodes.push(Box::new(click_mp3_copy_node));
+
+            edges.push(Edge {
+                nfrom: Box::new(ClickCheckMp3::new(check_mp3_path)),
+                nto: Box::new(CopyFile::new(
+                    click_mp3_copy_path,
+                    "click_check_mp3".to_string(),
+                )),
+            });
+
+            // Copy clicks.yml to ../clicks/<name>-clicks.yml
+            let clicks_copy_path = Path::new("../clicks").join(format!("{}-clicks.yml", file_stem));
+            let clicks_copy_node =
+                CopyFile::new(clicks_copy_path.clone(), "clicks.yml".to_string());
+            nodes.push(Box::new(clicks_copy_node));
+
+            edges.push(Edge {
+                nfrom: Box::new(
+                    ClickYml::new(clicks_yml_path, sandbox).map_err(ExpandError::Other)?,
+                ),
+                nto: Box::new(CopyFile::new(clicks_copy_path, "clicks.yml".to_string())),
             });
         }
 
         // Mount song.mp3 if has_mp3 is true
         if self.song.files.has_mp3 {
             let song_mp3_path = parent_dir.join("song.mp3");
-            nodes.push(Box::new(Mp3::new(song_mp3_path)));
+            nodes.push(Box::new(Mp3::new(song_mp3_path.clone())));
+
+            // Copy song.mp3 to ../mp3/<name>.mp3
+            let mp3_copy_path = Path::new("../mp3").join(format!("{}.mp3", file_stem));
+            let mp3_copy_node = CopyFile::new(mp3_copy_path.clone(), "mp3".to_string());
+            nodes.push(Box::new(mp3_copy_node));
+
+            edges.push(Edge {
+                nfrom: Box::new(Mp3::new(song_mp3_path)),
+                nto: Box::new(CopyFile::new(mp3_copy_path, "mp3".to_string())),
+            });
         }
 
         Ok((nodes, edges))


### PR DESCRIPTION
## Summary
- Add CopyFile nodes for `song.mp3`, `song-with-click.mp3`, and `clicks.yml` to deliver them to `mp3/`, `mp3-with-clicks/`, and `clicks/` directories
- Create sandbox directories and include them in both S3 upload and local delivery loops
- Bump version to 0.0.24

## Test plan
- [x] `cargo test --lib` — 36 passed, 1 ignored
- [x] `cargo clippy --lib` — no new warnings
- [x] `cargo fmt` — clean
- [x] `cargo doc --no-deps` — builds
- [x] Full example run produces correct delivery files

🤖 Generated with [Claude Code](https://claude.com/claude-code)