### PR TITLE
Add publish Makefile target, bump version to 0.0.25

### DIFF
--- a/band-songbook/Cargo.toml
+++ b/band-songbook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "band-songbook"
-version = "0.0.24"
+version = "0.0.25"
 edition = "2024"
 description = "Build system for generating PDF songbooks with chord charts and LilyPond music notation"
 license = "MIT"

--- a/band-songbook/Makefile
+++ b/band-songbook/Makefile
@@ -35,6 +35,10 @@ run-all: ## Build songs from local
 		--delivery delivery \
 		--pattern u2
 
+publish: ## Publish crate to crates.io via GitHub Actions
+	gh workflow run "Publish band-songbook" -f dry_run=false
+	@echo "Triggered publish workflow. Monitor with: gh run list --workflow='Publish band-songbook' --limit 1"
+
 refresh-and-reset: ## Reset work branch to main (fetch, reset, force push)
 	@branch=$$(git rev-parse --abbrev-ref HEAD); \
 	if [ "$$branch" != "work" ]; then echo "Error: not on work branch (on $$branch)"; exit 1; fi


### PR DESCRIPTION
## Summary
- Add `make publish` target to trigger the crates.io publish workflow via GitHub Actions
- Bump version to 0.0.25

## Test plan
- [x] `make help` shows new publish target
- [x] Workflow triggered successfully with `make publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)