### PR TITLE
Bump version to 0.0.26

### DIFF
--- a/band-songbook/Cargo.toml
+++ b/band-songbook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "band-songbook"
-version = "0.0.25"
+version = "0.0.26"
 edition = "2024"
 description = "Build system for generating PDF songbooks with chord charts and LilyPond music notation"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 0.0.26 for crates.io publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)