### PR TITLE
Auto-scale tikzpicture to fit page width

### DIFF
--- a/band-songbook/Cargo.toml
+++ b/band-songbook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "band-songbook"
-version = "0.0.27"
+version = "0.0.28"
 edition = "2024"
 description = "Build system for generating PDF songbooks with chord charts and LilyPond music notation"
 license = "MIT"

--- a/band-songbook/src/resources/texfiles/song.tikz
+++ b/band-songbook/src/resources/texfiles/song.tikz
@@ -15,6 +15,7 @@
 %\tikzset{declare
 %function={Gauss(\x,mu,\sig)=1/(\sig*sqrt(2*pi))*exp(-0.5*((\x-\mu)/\sig)^2);}}
 
+\begin{adjustbox}{max width=\textwidth}
 \begin{tikzpicture}[]
     \usetikzlibrary{arrows.meta}
 
@@ -101,3 +102,4 @@
 {{/each}}
 
 \end{tikzpicture}
+\end{adjustbox}


### PR DESCRIPTION
## Summary
- Wrap song.tikz in `adjustbox{max width=\textwidth}` to prevent clipping on two-column songs
- Only scales down when needed; single-column songs remain unchanged
- Bump version to 0.0.28

## Test plan
- [x] Two-column song (Muse - Can't Take My Eyes Off You) no longer clips
- [x] Single-column song (PJ Harvey - Dress) renders at normal size

🤖 Generated with [Claude Code](https://claude.com/claude-code)