### PR TITLE
Use bar/beat in Click, mm:ss time format, bump to 0.0.30

### DIFF
--- a/band-songbook/Cargo.toml
+++ b/band-songbook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "band-songbook"
-version = "0.0.29"
+version = "0.0.30"
 edition = "2024"
 description = "Build system for generating PDF songbooks with chord charts and LilyPond music notation"
 license = "MIT"

--- a/band-songbook/src/model.rs
+++ b/band-songbook/src/model.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// A complete song definition, deserialized from `song.yml`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -167,15 +167,41 @@ pub struct Clicks {
     pub clicks: Vec<f64>,
 }
 
-/// A single click event with its beat number, time, and description.
+/// A single click event with its bar/beat position, time, and description.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Click {
-    /// Beat number (1-based).
-    pub beat_number: u32,
+    /// Bar number (1-based).
+    pub bar_number: u32,
+    /// Beat within the bar (1-based, e.g. 1–4 for 4/4 time).
+    pub beat_in_bar_number: u32,
     /// Absolute time in seconds from the start of the audio.
+    /// Deserialized from `"mm:ss.ms"` format (e.g. `"1:30.5"` = 90.5 seconds).
+    #[serde(deserialize_with = "deserialize_time")]
     pub time: f64,
     /// Description of this click (e.g. bar number, section name).
     pub description: String,
+}
+
+/// Parse a time string in `"mm:ss.ms"` format into seconds.
+fn parse_time(s: &str) -> Result<f64, String> {
+    let (minutes, rest) = s
+        .split_once(':')
+        .ok_or_else(|| format!("expected mm:ss.ms format, got {s}"))?;
+    let minutes: f64 = minutes
+        .parse()
+        .map_err(|e| format!("invalid minutes in {s}: {e}"))?;
+    let seconds: f64 = rest
+        .parse()
+        .map_err(|e| format!("invalid seconds in {s}: {e}"))?;
+    Ok(minutes * 60.0 + seconds)
+}
+
+fn deserialize_time<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    parse_time(&s).map_err(serde::de::Error::custom)
 }
 
 /// A full click track definition with all click events.

--- a/band-songbook/src/nodes/clickdef.rs
+++ b/band-songbook/src/nodes/clickdef.rs
@@ -44,7 +44,7 @@ mod tests {
         let def_path = srcdir.path().join("clicks-def.yml");
         std::fs::write(
             &def_path,
-            "clicks:\n- beat_number: 1\n  time: 0.0\n  description: bar 1\n- beat_number: 5\n  time: 1.714\n  description: bar 2\n",
+            "clicks:\n- bar_number: 1\n  beat_in_bar_number: 1\n  time: \"0:0.0\"\n  description: bar 1\n- bar_number: 2\n  beat_in_bar_number: 1\n  time: \"0:1.714\"\n  description: bar 2\n",
         )
         .unwrap();
 
@@ -53,10 +53,11 @@ mod tests {
 
         let node = node.unwrap();
         assert_eq!(node.data.clicks.len(), 2);
-        assert_eq!(node.data.clicks[0].beat_number, 1);
+        assert_eq!(node.data.clicks[0].bar_number, 1);
+        assert_eq!(node.data.clicks[0].beat_in_bar_number, 1);
         assert!((node.data.clicks[0].time - 0.0).abs() < 1e-9);
         assert_eq!(node.data.clicks[0].description, "bar 1");
-        assert_eq!(node.data.clicks[1].beat_number, 5);
+        assert_eq!(node.data.clicks[1].bar_number, 2);
         assert_eq!(node.tag(), "clicks-def");
     }
 

--- a/band-songbook/src/nodes/clickyml.rs
+++ b/band-songbook/src/nodes/clickyml.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use yamake::model::GNode;
 
-use crate::model::{Clicks, ClicksDefinition};
+use crate::model::{Click, Clicks, ClicksDefinition};
 
 /// Build node for `clicks.yml` that generates click times by linear interpolation
 /// from a `ClickDef` predecessor.
@@ -15,11 +15,17 @@ impl ClickYml {
     }
 }
 
+/// Compute the absolute beat number (1-based) from bar and beat-in-bar.
+/// Uses 4 beats per bar: `(bar_number - 1) * 4 + beat_in_bar_number`.
+fn absolute_beat(click: &Click) -> u32 {
+    (click.bar_number - 1) * 4 + click.beat_in_bar_number
+}
+
 /// Interpolate click times from a `ClicksDefinition`.
 ///
 /// For each pair of consecutive Click entries, linearly interpolates
-/// the beat times between them. For example, if beat 1 is at 0.0s and
-/// beat 5 is at 2.0s, beats 1–4 will be at 0.0, 0.5, 1.0, 1.5.
+/// the beat times between them. For example, if bar 1 beat 1 is at 0.0s and
+/// bar 2 beat 1 is at 2.0s, the 4 intermediate beats will be at 0.0, 0.5, 1.0, 1.5.
 fn interpolate(def: &ClicksDefinition) -> Vec<f64> {
     if def.clicks.is_empty() {
         return vec![];
@@ -32,7 +38,7 @@ fn interpolate(def: &ClicksDefinition) -> Vec<f64> {
     for window in def.clicks.windows(2) {
         let from = &window[0];
         let to = &window[1];
-        let n_beats = to.beat_number - from.beat_number;
+        let n_beats = absolute_beat(to) - absolute_beat(from);
         for i in 0..n_beats {
             let t = from.time + (to.time - from.time) * (i as f64) / (n_beats as f64);
             result.push(t);
@@ -123,45 +129,50 @@ mod tests {
     use crate::nodes::ClickDef;
     #[test]
     fn test_interpolate_two_points() {
+        // bar 1 beat 1 (abs=1) at 10s, bar 3 beat 3 (abs=11) at 20s → 10 intervals of 1s
         let def = ClicksDefinition {
             clicks: vec![
                 Click {
-                    beat_number: 1,
-                    time: 0.0,
+                    bar_number: 1,
+                    beat_in_bar_number: 1,
+                    time: 10.0,
                     description: "bar 1".to_string(),
                 },
                 Click {
-                    beat_number: 5,
-                    time: 2.0,
-                    description: "bar 2".to_string(),
+                    bar_number: 3,
+                    beat_in_bar_number: 3,
+                    time: 20.0,
+                    description: "bar 3 beat 3".to_string(),
                 },
             ],
         };
         let result = interpolate(&def);
-        assert_eq!(result.len(), 5); // beats 1,2,3,4,5
-        assert!((result[0] - 0.0).abs() < 1e-9);
-        assert!((result[1] - 0.5).abs() < 1e-9);
-        assert!((result[2] - 1.0).abs() < 1e-9);
-        assert!((result[3] - 1.5).abs() < 1e-9);
-        assert!((result[4] - 2.0).abs() < 1e-9);
+        assert_eq!(result.len(), 11); // beats 1..=11
+        assert!((result[0] - 10.0).abs() < 1e-9);
+        assert!((result[2] - 12.0).abs() < 1e-9); // beat 3 at 12s
+        assert!((result[10] - 20.0).abs() < 1e-9);
     }
 
     #[test]
     fn test_interpolate_three_points() {
+        // bar1:beat1 (abs=1) at 0s, bar1:beat3 (abs=3) at 1s, bar2:beat1 (abs=5) at 3s
         let def = ClicksDefinition {
             clicks: vec![
                 Click {
-                    beat_number: 1,
+                    bar_number: 1,
+                    beat_in_bar_number: 1,
                     time: 0.0,
                     description: "bar 1".to_string(),
                 },
                 Click {
-                    beat_number: 3,
+                    bar_number: 1,
+                    beat_in_bar_number: 3,
                     time: 1.0,
                     description: "bar 1 beat 3".to_string(),
                 },
                 Click {
-                    beat_number: 5,
+                    bar_number: 2,
+                    beat_in_bar_number: 1,
                     time: 3.0,
                     description: "bar 2".to_string(),
                 },
@@ -186,7 +197,8 @@ mod tests {
     fn test_interpolate_single() {
         let def = ClicksDefinition {
             clicks: vec![Click {
-                beat_number: 1,
+                bar_number: 1,
+                beat_in_bar_number: 1,
                 time: 0.0,
                 description: "start".to_string(),
             }],
@@ -205,7 +217,7 @@ mod tests {
         // Write a clicks-def.yml
         std::fs::write(
             song_dir.join("clicks-def.yml"),
-            "clicks:\n- beat_number: 1\n  time: 0.0\n  description: bar 1\n- beat_number: 5\n  time: 2.0\n  description: bar 2\n",
+            "clicks:\n- bar_number: 1\n  beat_in_bar_number: 1\n  time: \"0:0.0\"\n  description: bar 1\n- bar_number: 2\n  beat_in_bar_number: 1\n  time: \"0:2.0\"\n  description: bar 2\n",
         )
         .unwrap();
 

--- a/band-songbook/src/nodes/songyml.rs
+++ b/band-songbook/src/nodes/songyml.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use yamake::model::{Edge, ExpandError, ExpandResult, GNode, GRootNode};
 
 use super::{
-    ClickCheckMp3, ClickYml, CopyFile, LilypondFile, LyTexFile, Mp3, PdfFile, SongTikz,
+    ClickYml, CopyFile, LilypondFile, LyTexFile, Mp3, PdfFile, SongTikz,
     StrudelFile, TexFile, TexOfLilypond,
 };
 use crate::chords::bar_numbering::barcount_map_of_structure;
@@ -514,36 +514,30 @@ impl GRootNode for SongYml {
             let clicks_yml_path = parent_dir.join("clicks.yml");
             nodes.push(Box::new(ClickYml::new(clicks_yml_path.clone())));
 
-            let check_mp3_path = parent_dir.join("song-with-click.mp3");
-            nodes.push(Box::new(ClickCheckMp3::new(check_mp3_path.clone())));
-
-            // Edge: clicks.yml -> song-with-click.mp3
-            edges.push(Edge {
-                nfrom: Box::new(ClickYml::new(clicks_yml_path.clone())),
-                nto: Box::new(ClickCheckMp3::new(check_mp3_path.clone())),
-            });
-
-            // Edge: song.mp3 -> song-with-click.mp3
-            let song_mp3_path = parent_dir.join("song.mp3");
-            edges.push(Edge {
-                nfrom: Box::new(Mp3::new(song_mp3_path)),
-                nto: Box::new(ClickCheckMp3::new(check_mp3_path.clone())),
-            });
-
-            // Copy song-with-click.mp3 to ../mp3-with-clicks/<name>.mp3
-            let click_mp3_copy_path =
-                Path::new("../mp3-with-clicks").join(format!("{}-with-clicks.mp3", file_stem));
-            let click_mp3_copy_node =
-                CopyFile::new(click_mp3_copy_path.clone(), "click_check_mp3".to_string());
-            nodes.push(Box::new(click_mp3_copy_node));
-
-            edges.push(Edge {
-                nfrom: Box::new(ClickCheckMp3::new(check_mp3_path)),
-                nto: Box::new(CopyFile::new(
-                    click_mp3_copy_path,
-                    "click_check_mp3".to_string(),
-                )),
-            });
+            // TODO: re-enable song-with-click.mp3 generation
+            // let check_mp3_path = parent_dir.join("song-with-click.mp3");
+            // nodes.push(Box::new(ClickCheckMp3::new(check_mp3_path.clone())));
+            // edges.push(Edge {
+            //     nfrom: Box::new(ClickYml::new(clicks_yml_path.clone())),
+            //     nto: Box::new(ClickCheckMp3::new(check_mp3_path.clone())),
+            // });
+            // let song_mp3_path = parent_dir.join("song.mp3");
+            // edges.push(Edge {
+            //     nfrom: Box::new(Mp3::new(song_mp3_path)),
+            //     nto: Box::new(ClickCheckMp3::new(check_mp3_path.clone())),
+            // });
+            // let click_mp3_copy_path =
+            //     Path::new("../mp3-with-clicks").join(format!("{}-with-clicks.mp3", file_stem));
+            // let click_mp3_copy_node =
+            //     CopyFile::new(click_mp3_copy_path.clone(), "click_check_mp3".to_string());
+            // nodes.push(Box::new(click_mp3_copy_node));
+            // edges.push(Edge {
+            //     nfrom: Box::new(ClickCheckMp3::new(check_mp3_path)),
+            //     nto: Box::new(CopyFile::new(
+            //         click_mp3_copy_path,
+            //         "click_check_mp3".to_string(),
+            //     )),
+            // });
 
             // Copy clicks.yml to ../clicks/<name>-clicks.yml
             let clicks_copy_path = Path::new("../clicks").join(format!("{}-clicks.yml", file_stem));

--- a/band-songbook/src/tests.rs
+++ b/band-songbook/src/tests.rs
@@ -563,7 +563,7 @@ structure: []
         .expect("copy clicks.mp3");
     std::fs::write(
         song_dir.join("clicks-def.yml"),
-        "clicks:\n- beat_number: 1\n  time: 0.0\n  description: start\n- beat_number: 3\n  time: 0.5\n  description: end\n",
+        "clicks:\n- bar_number: 1\n  beat_in_bar_number: 1\n  time: \"0:0.0\"\n  description: start\n- bar_number: 1\n  beat_in_bar_number: 3\n  time: \"0:0.5\"\n  description: end\n",
     )
     .expect("write clicks-def.yml");
     std::fs::copy("tests/data/click/clicks.mp3", song_dir.join("song.mp3")).expect("copy song.mp3");

--- a/band-songbook/tests/data/mademoiselle_K/ca_me_vexe/clicks-def.yml
+++ b/band-songbook/tests/data/mademoiselle_K/ca_me_vexe/clicks-def.yml
@@ -1,10 +1,13 @@
 clicks:
-- beat_number: 1
-  time: 0.0
+- bar_number: 1
+  beat_in_bar_number: 1
+  time: "0:0.0"
   description: bar 1
-- beat_number: 5
-  time: 1.714
+- bar_number: 2
+  beat_in_bar_number: 1
+  time: "0:1.714"
   description: bar 2
-- beat_number: 9
-  time: 3.428
+- bar_number: 3
+  beat_in_bar_number: 1
+  time: "0:3.428"
   description: end


### PR DESCRIPTION
## Summary
- Replace `beat_number` with `bar_number` and `beat_in_bar_number` (both 1-based) in `Click` struct
- Deserialize `Click.time` from `"mm:ss.ms"` string format (e.g. `"1:30.5"` = 90.5s)
- Comment out `song-with-click.mp3` generation (TODO)
- Bump version to 0.0.30

## Test plan
- [x] `cargo test --lib` — 44 passed
- [x] `cargo clippy --lib` — 0 warnings
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)